### PR TITLE
Show licenses USEID-361

### DIFF
--- a/.github/workflows/Preview.yml
+++ b/.github/workflows/Preview.yml
@@ -28,7 +28,7 @@ jobs:
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: bundle install --path=vendor
       - name: Brew bundle
-        run: arch -arm64 brew bundle --no-lock
+        run: ./native_arch.sh brew bundle --no-lock
       - name: Save Dependencies
         uses: actions/cache@v2
         if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/Production.yml
+++ b/.github/workflows/Production.yml
@@ -28,7 +28,7 @@ jobs:
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: bundle install --path=vendor
       - name: Brew bundle
-        run: arch -arm64 brew bundle --no-lock
+        run: ./native_arch.sh brew bundle --no-lock
       - name: Save Dependencies
         uses: actions/cache@v2
         if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -35,7 +35,7 @@ jobs:
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: bundle install --path=vendor
       - name: Brew bundle
-        run: brew bundle --no-lock
+        run: ./native_arch.sh brew bundle --no-lock
       - name: Save Dependencies
         uses: actions/cache@v2
         if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,7 @@ Temporary Items
 # Application specific files to ignore
 BundID/OpenECard/OpenEcard.framework/
 BundID/OpenECard/OpenEcard.xcframework
-BundID/Helpers/LocalizedStrings+Generated.swift
+BundID/Generated
 .swift-packages
 swiftlint.html
 BundIDTests/Generated

--- a/Brewfile
+++ b/Brewfile
@@ -3,3 +3,6 @@ brew "swiftlint"
 
 tap "getsentry/tools"
 brew "getsentry/tools/sentry-cli"
+
+tap "mono0926/license-plist"
+brew "mono0926/license-plist/license-plist"

--- a/BundID.xcodeproj/project.pbxproj
+++ b/BundID.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		D28D280228B7A9F5008DA310 /* SetupDone.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28D280028B7A9F5008DA310 /* SetupDone.swift */; };
 		D28D280328B7A9F5008DA310 /* SetupIncorrectTransportPIN.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28D280128B7A9F5008DA310 /* SetupIncorrectTransportPIN.swift */; };
 		D2A6773828B4DD5D0033373E /* Array+SafeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A6773728B4DD5D0033373E /* Array+SafeTests.swift */; };
-		E10BB69A28AF7FB2007EF50C /* LocalizedStrings+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FCE41282BFD4A00CD7AD6 /* LocalizedStrings+Generated.swift */; };
 		E10BB69B28AF83DD007EF50C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E1AB87AA2825238D00C7FC94 /* Localizable.strings */; };
 		E10BB69C28AF83E1007EF50C /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = E19D26B1282557B00005B111 /* Localizable.stringsdict */; };
 		E110400D281C389C004BA03E /* SetupIntro.swift in Sources */ = {isa = PBXBuildFile; fileRef = E110400C281C389C004BA03E /* SetupIntro.swift */; };
@@ -33,6 +32,7 @@
 		E13925CA28411D4C00161F5C /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = E13925C928411D4C00161F5C /* Lottie */; };
 		E13925CD28411DA600161F5C /* 38076-id-scan.json in Resources */ = {isa = PBXBuildFile; fileRef = E13925CC28411DA600161F5C /* 38076-id-scan.json */; };
 		E13925CF28411E2400161F5C /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13925CE28411E2300161F5C /* LottieView.swift */; };
+		E13A632128B8010A00AB7A39 /* LocalizedStrings+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FCE41282BFD4A00CD7AD6 /* LocalizedStrings+Generated.swift */; };
 		E13F9E3B2886F3420088E955 /* IdentificationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13F9E3A2886F3420088E955 /* IdentificationCoordinatorTests.swift */; };
 		E13F9E3D288802500088E955 /* UUID+InitFromNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13F9E3C288802500088E955 /* UUID+InitFromNumber.swift */; };
 		E13F9E3F288804140088E955 /* IdentificationScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13F9E3E288804140088E955 /* IdentificationScanTests.swift */; };
@@ -70,6 +70,11 @@
 		E1AB87AC2825238D00C7FC94 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E1AB87AA2825238D00C7FC94 /* Localizable.strings */; };
 		E1B6991C2869B31B00360273 /* DebugIDInteractionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B6991B2869B31B00360273 /* DebugIDInteractionManager.swift */; };
 		E1B7A4F628B674850086933E /* RichText in Frameworks */ = {isa = PBXBuildFile; productRef = E1B7A4F528B674850086933E /* RichText */; };
+		E1BC3D7928B7E40B007A7B39 /* LicensesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BC3D7828B7E40B007A7B39 /* LicensesView.swift */; };
+		E1BC3D8128B7E73B007A7B39 /* Licenses in Resources */ = {isa = PBXBuildFile; fileRef = E1BC3D7F28B7E73B007A7B39 /* Licenses */; };
+		E1BC3D8228B7E73B007A7B39 /* Licenses.plist in Resources */ = {isa = PBXBuildFile; fileRef = E1BC3D8028B7E73B007A7B39 /* Licenses.plist */; };
+		E1BC3D8628B7E919007A7B39 /* LicensePlistViewController in Frameworks */ = {isa = PBXBuildFile; productRef = E1BC3D8528B7E919007A7B39 /* LicensePlistViewController */; };
+		E1BD6C792847A2E5003048E4 /* SetupDone.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BD6C782847A2E5003048E4 /* SetupDone.swift */; };
 		E1C2D8BA28620E2B000E0F5B /* IdentificationScan.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C2D8B928620E2B000E0F5B /* IdentificationScan.swift */; };
 		E1CD8E88281FF62F008ADA2A /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CD8E87281FF62F008ADA2A /* Colors.swift */; };
 		E1CD8E8C281FFCC1008ADA2A /* BundesSans-DTP-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = E1CD8E8A281FFCC1008ADA2A /* BundesSans-DTP-Regular.otf */; };
@@ -203,6 +208,10 @@
 		E1AB87A3282413A700C7FC94 /* PINTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PINTextField.swift; sourceTree = "<group>"; };
 		E1AB87AB2825238D00C7FC94 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E1B6991B2869B31B00360273 /* DebugIDInteractionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugIDInteractionManager.swift; sourceTree = "<group>"; };
+		E1BC3D7828B7E40B007A7B39 /* LicensesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensesView.swift; sourceTree = "<group>"; };
+		E1BC3D7F28B7E73B007A7B39 /* Licenses */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Licenses; sourceTree = "<group>"; };
+		E1BC3D8028B7E73B007A7B39 /* Licenses.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Licenses.plist; sourceTree = "<group>"; };
+		E1BD6C782847A2E5003048E4 /* SetupDone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupDone.swift; sourceTree = "<group>"; };
 		E1C2D8B928620E2B000E0F5B /* IdentificationScan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentificationScan.swift; sourceTree = "<group>"; };
 		E1CD8E87281FF62F008ADA2A /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		E1CD8E8A281FFCC1008ADA2A /* BundesSans-DTP-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "BundesSans-DTP-Regular.otf"; sourceTree = "<group>"; };
@@ -272,6 +281,7 @@
 			files = (
 				E16708AA283D1076001A1637 /* TCACoordinators in Frameworks */,
 				E1B7A4F628B674850086933E /* RichText in Frameworks */,
+				E1BC3D8628B7E919007A7B39 /* LicensePlistViewController in Frameworks */,
 				E13925CA28411D4C00161F5C /* Lottie in Frameworks */,
 				E15C23002850F5A8005CCBB9 /* OpenEcard in Frameworks */,
 				E128E0BA288941DC00C5195F /* Sentry in Frameworks */,
@@ -353,7 +363,6 @@
 		E15FCE40282BFD4A00CD7AD6 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				E15FCE41282BFD4A00CD7AD6 /* LocalizedStrings+Generated.swift */,
 				E1AAACE728350FD500A51183 /* Array+Safe.swift */,
 				E1AAACEA2836668200A51183 /* ShakeEffect.swift */,
 				E16708BB283D824D001A1637 /* Scheduler+Animation.swift */,
@@ -403,6 +412,7 @@
 			isa = PBXGroup;
 			children = (
 				E16708AD283D4224001A1637 /* HomeView.swift */,
+				E1BC3D7828B7E40B007A7B39 /* LicensesView.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -467,6 +477,16 @@
 			path = Theme;
 			sourceTree = "<group>";
 		};
+		E1BC3D7A28B7E5C0007A7B39 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				E1BC3D7F28B7E73B007A7B39 /* Licenses */,
+				E1BC3D8028B7E73B007A7B39 /* Licenses.plist */,
+				E15FCE41282BFD4A00CD7AD6 /* LocalizedStrings+Generated.swift */,
+			);
+			path = Generated;
+			sourceTree = "<group>";
+		};
 		E1CD8E89281FFCA0008ADA2A /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -523,6 +543,7 @@
 		E5CEB27C281041330076B9FE /* BundID */ = {
 			isa = PBXGroup;
 			children = (
+				E1BC3D7A28B7E5C0007A7B39 /* Generated */,
 				E15FCE40282BFD4A00CD7AD6 /* Helpers */,
 				E13925BF2841105A00161F5C /* Types */,
 				E593E277281686D000154EB0 /* Managers */,
@@ -622,6 +643,7 @@
 			buildConfigurationList = E5CEB288281041340076B9FE /* Build configuration list for PBXNativeTarget "BundID" */;
 			buildPhases = (
 				E15FCE3F282BFCEA00CD7AD6 /* Localize via SwiftGen */,
+				E1BC3D8328B7E78F007A7B39 /* Generate licenses */,
 				E5CEB276281041330076B9FE /* Sources */,
 				E5CEB277281041330076B9FE /* Frameworks */,
 				E5CEB278281041330076B9FE /* Resources */,
@@ -638,6 +660,7 @@
 				E15C22FF2850F5A8005CCBB9 /* OpenEcard */,
 				E128E0B9288941DC00C5195F /* Sentry */,
 				E1B7A4F528B674850086933E /* RichText */,
+				E1BC3D8528B7E919007A7B39 /* LicensePlistViewController */,
 			);
 			productName = BundID;
 			productReference = E5CEB27A281041330076B9FE /* BundID.app */;
@@ -676,12 +699,13 @@
 			);
 			mainGroup = E5CEB271281041330076B9FE;
 			packageReferences = (
-				E16708A8283D1076001A1637 /* XCRemoteSwiftPackageReference "TCACoordinators.git" */,
+				E16708A8283D1076001A1637 /* XCRemoteSwiftPackageReference "TCACoordinators" */,
 				E13925B928410F3F00161F5C /* XCRemoteSwiftPackageReference "Cuckoo" */,
 				E13925C828411D4C00161F5C /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				E15C22FE2850F5A8005CCBB9 /* XCRemoteSwiftPackageReference "open-ecard-ios" */,
-				E128E0B8288941DC00C5195F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */,
-				E1B7A4F428B674850086933E /* XCRemoteSwiftPackageReference "RichText.git" */,
+				E128E0B8288941DC00C5195F /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				E1B7A4F428B674850086933E /* XCRemoteSwiftPackageReference "RichText" */,
+				E1BC3D8428B7E919007A7B39 /* XCRemoteSwiftPackageReference "LicensePlistViewController" */,
 			);
 			productRefGroup = E5CEB27B281041330076B9FE /* Products */;
 			projectDirPath = "";
@@ -723,7 +747,9 @@
 				E5CEB282281041340076B9FE /* Assets.xcassets in Resources */,
 				B9C7735028B3C64100E41332 /* animation_id-scan.json in Resources */,
 				E1CD8E8D281FFCC1008ADA2A /* BundesSans-DTP-Bold.otf in Resources */,
+				E1BC3D8128B7E73B007A7B39 /* Licenses in Resources */,
 				E19D26AF282557B00005B111 /* Localizable.stringsdict in Resources */,
+				E1BC3D8228B7E73B007A7B39 /* Licenses.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -766,11 +792,32 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(PROJECT_DIR)/BundID/Helpers/LocalizedStrings+Generated.swift",
+				"$(PROJECT_DIR)/BundID/Generated/LocalizedStrings+Generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "PATH=$PATH:/opt/homebrew/bin\nswiftgen\n";
+		};
+		E1BC3D8328B7E78F007A7B39 /* Generate licenses */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Package.resolved",
+			);
+			name = "Generate licenses";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(PROJECT_DIR)/BundID/Generated/Licenses.plist",
+				"$(PROJECT_DIR)/BundID/Generated/Licenses/",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "PATH=$PATH:/opt/homebrew/bin\nlicense-plist --suppress-opening-directory --fail-if-missing-license --output-path BundID/Generated --prefix Licenses\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -779,7 +826,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E10BB69A28AF7FB2007EF50C /* LocalizedStrings+Generated.swift in Sources */,
+				E13A632128B8010A00AB7A39 /* LocalizedStrings+Generated.swift in Sources */,
 				E11EB2A928537DE1008B4042 /* XCUITestHelper.swift in Sources */,
 				E156DD02287EF9C200C88914 /* XCUITestDeeplinking.swift in Sources */,
 				E18E223A285349D200221DB1 /* BundIDUITests.swift in Sources */,
@@ -869,6 +916,7 @@
 				E1CD8E9528215971008ADA2A /* PINEntryView.swift in Sources */,
 				E13925B82840FB7700161F5C /* Types.swift in Sources */,
 				E13925C72841119400161F5C /* MockIDInteractionManager.swift in Sources */,
+				E1BC3D7928B7E40B007A7B39 /* LicensesView.swift in Sources */,
 				E16708B1283D4EAC001A1637 /* AppEnvironment.swift in Sources */,
 				E593E2722816864800154EB0 /* ControllerCallback.swift in Sources */,
 				E1CD8E88281FF62F008ADA2A /* Colors.swift in Sources */,
@@ -1527,7 +1575,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		E128E0B8288941DC00C5195F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */ = {
+		E128E0B8288941DC00C5195F /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
@@ -1559,7 +1607,7 @@
 				minimumVersion = 2.1.2;
 			};
 		};
-		E16708A8283D1076001A1637 /* XCRemoteSwiftPackageReference "TCACoordinators.git" */ = {
+		E16708A8283D1076001A1637 /* XCRemoteSwiftPackageReference "TCACoordinators" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/johnpatrickmorgan/TCACoordinators.git";
 			requirement = {
@@ -1567,7 +1615,7 @@
 				minimumVersion = 0.1.2;
 			};
 		};
-		E1B7A4F428B674850086933E /* XCRemoteSwiftPackageReference "RichText.git" */ = {
+		E1B7A4F428B674850086933E /* XCRemoteSwiftPackageReference "RichText" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/digitalservicebund/RichText.git";
 			requirement = {
@@ -1575,12 +1623,20 @@
 				kind = branch;
 			};
 		};
+		E1BC3D8428B7E919007A7B39 /* XCRemoteSwiftPackageReference "LicensePlistViewController" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/yhirano/LicensePlistViewController.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.2.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		E128E0B9288941DC00C5195F /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = E128E0B8288941DC00C5195F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
+			package = E128E0B8288941DC00C5195F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
 		};
 		E13925C1284110FD00161F5C /* Cuckoo */ = {
@@ -1600,13 +1656,18 @@
 		};
 		E16708A9283D1076001A1637 /* TCACoordinators */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = E16708A8283D1076001A1637 /* XCRemoteSwiftPackageReference "TCACoordinators.git" */;
+			package = E16708A8283D1076001A1637 /* XCRemoteSwiftPackageReference "TCACoordinators" */;
 			productName = TCACoordinators;
 		};
 		E1B7A4F528B674850086933E /* RichText */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = E1B7A4F428B674850086933E /* XCRemoteSwiftPackageReference "RichText.git" */;
+			package = E1B7A4F428B674850086933E /* XCRemoteSwiftPackageReference "RichText" */;
 			productName = RichText;
+		};
+		E1BC3D8528B7E919007A7B39 /* LicensePlistViewController */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E1BC3D8428B7E919007A7B39 /* XCRemoteSwiftPackageReference "LicensePlistViewController" */;
+			productName = LicensePlistViewController;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/BundID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BundID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "licenseplistviewcontroller",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/yhirano/LicensePlistViewController.git",
+      "state" : {
+        "revision" : "1fb4a71c2e37a4ea1a9a135c6d2aff65130c8a55",
+        "version" : "2.2.0"
+      }
+    },
+    {
       "identity" : "lottie-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-ios",

--- a/BundID/Views/Home/HomeView.swift
+++ b/BundID/Views/Home/HomeView.swift
@@ -110,8 +110,10 @@ struct HomeView: View {
     var listView: some View {
         VStack(alignment: .leading) {
             VStack(alignment: .leading, spacing: 0) {
-                Button {
-                    
+                NavigationLink {
+                    LicensesView()
+                        .navigationTitle(L10n.Home.Actions.licenses)
+                        .ignoresSafeArea()
                 } label: {
                     Text(L10n.Home.Actions.licenses)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/BundID/Views/Home/LicensesView.swift
+++ b/BundID/Views/Home/LicensesView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import UIKit
+import LicensePlistViewController
+
+struct LicensesView: UIViewControllerRepresentable {
+    
+    func makeUIViewController(context: Context) -> LicensePlistViewController {
+        return LicensePlistViewController(fileNamed: "Licenses", tableViewStyle: .insetGrouped)
+    }
+    
+    func updateUIViewController(_ uiViewController: LicensePlistViewController, context: Context) {
+        
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+    
+    class Coordinator: NSObject { }
+}

--- a/native_arch.sh
+++ b/native_arch.sh
@@ -1,0 +1,16 @@
+set -e
+
+# Our GitHub action is executed either on an x64 or Rosetta 2 emulated arm64 host. 
+# Brew needs to be executed on the host arch in order to function correctly.
+# Similar problem and more info here: https://gregmfoster.medium.com/using-m1-mac-minis-to-power-our-github-actions-ios-ci-540c55af13ea
+
+EXIT_CODE=0
+arch -arm64 echo > /dev/null || EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then 
+  # if we can execute on arm64 arch, it means we are an arm64 host system (possible emulated by Rosetta 2), so use that arch
+  arch -arm64 "$@"
+else 
+  # if we can not, we can simply execute the command on the host system (intel based)
+  "$@"
+fi

--- a/swiftgen.yml
+++ b/swiftgen.yml
@@ -3,6 +3,6 @@ strings:
     - BundID/Resources/de.lproj
   outputs:
     - templateName: structured-swift5
-      output: BundID/Helpers/LocalizedStrings+Generated.swift
+      output: BundID/Generated/LocalizedStrings+Generated.swift
   options:
     separator: "_"


### PR DESCRIPTION
- Show licenses by generating a license plist via https://github.com/mono0926/LicensePlist and displaying it via https://github.com/yhirano/LicensePlistViewController directly in the app.
- Move the generated localization files to a new Generated folder, which is ignored via gitignore.
- CI: Escape Rosetta under M1-Macs and stay compatible when running on intel machines