### PR TITLE
Add empty release workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,11 @@
+name: Release
+on: [workflow_dispatch]
+
+jobs:
+  none:
+    runs-on: self-hosted
+    steps:
+      - name: Ensure on release branch
+        run: |
+          echo "Ensuring current branch $GITHUB_REF is 'release' branch…"
+          [[ $GITHUB_REF -eq 'refs/heads/release' ]]


### PR DESCRIPTION
Add an empty release workflow so we can trigger it via the GitHub web interface