### PR TITLE
Allow going back to identification overview screen

### DIFF
--- a/BundID/Views/Identification/IdentificationDone.swift
+++ b/BundID/Views/Identification/IdentificationDone.swift
@@ -43,5 +43,6 @@ struct IdentificationDone: View {
                                             action: viewStore.hasValidURL ? .openURL(URL(string: viewStore.redirectURL)!) : .close))
             .navigationBarBackButtonHidden(true)
         }
+        .navigationBarHidden(false)
     }
 }

--- a/BundID/Views/Identification/IdentificationOverview/IdentificationOverview.swift
+++ b/BundID/Views/Identification/IdentificationOverview/IdentificationOverview.swift
@@ -7,6 +7,9 @@ struct IdentificationOverviewLoadedState: Identifiable, Equatable {
     let request: EIDAuthenticationRequest
     var handler: IdentifiableCallback<FlaggedAttributes>
     
+    // used when going back to the overview screen when we already received a pin handler
+    var pinHandler: PINCallback?
+    
     var requiredReadAttributes: IdentifiedArrayOf<IDCardAttribute> {
         let requiredAttributes = request.readAttributes.compactMap { (key: IDCardAttribute, isRequired: Bool) in
             isRequired ? key : nil
@@ -50,7 +53,7 @@ enum IdentificationOverviewLoadedAction: Equatable {
     case idInteractionEvent(Result<EIDInteractionEvent, IDCardInteractionError>)
     case moreInfo
     case callbackReceived(EIDAuthenticationRequest, PINCallback)
-    case done
+    case confirm
     case failure(IdentifiableError)
 }
 

--- a/BundID/Views/Identification/IdentificationPersonalPIN.swift
+++ b/BundID/Views/Identification/IdentificationPersonalPIN.swift
@@ -74,7 +74,6 @@ struct IdentificationPersonalPIN: View {
             }
             .padding(.horizontal)
         }
-        .navigationBarBackButtonHidden(true)
         .navigationBarHidden(false)
     }
 }

--- a/BundIDTests/IdentificationOverviewTests.swift
+++ b/BundIDTests/IdentificationOverviewTests.swift
@@ -11,11 +11,19 @@ final class IdentificationOverviewTests: XCTestCase {
     var scheduler: TestSchedulerOf<DispatchQueue>!
     var mockAnalyticsClient: MockAnalyticsClient!
     var environment: AppEnvironment!
+    var uuidCount = 0
+    
+    func uuidFactory() -> UUID {
+        let currentCount = self.uuidCount
+        self.uuidCount += 1
+        return UUID(number: currentCount)
+    }
     
     override func setUp() {
         scheduler = DispatchQueue.test
         mockAnalyticsClient = MockAnalyticsClient()
-        environment = AppEnvironment.mocked(analytics: mockAnalyticsClient)
+        environment = AppEnvironment.mocked(uuidFactory: uuidFactory,
+                                            analytics: mockAnalyticsClient)
         
         stub(mockAnalyticsClient) {
             $0.track(view: any()).thenDoNothing()
@@ -38,5 +46,107 @@ final class IdentificationOverviewTests: XCTestCase {
         verify(mockAnalyticsClient).track(event: AnalyticsEvent(category: "identification",
                                                                 action: "loadingFailed",
                                                                 name: "attributes"))
+    }
+    
+    func testLoadingSuccess() {
+        let store = TestStore(
+            initialState: IdentificationOverviewState.loading(.init()),
+            reducer: identificationOverviewReducer,
+            environment: environment
+        )
+        
+        let request = EIDAuthenticationRequest.preview
+        let handler: (FlaggedAttributes) -> Void = { attributes in }
+        
+        store.send(IdentificationOverviewAction.loading(.idInteractionEvent(.success(.requestAuthenticationRequestConfirmation(request, handler)))))
+        
+        let callback = IdentifiableCallback(id: UUID(number: 0), callback: handler)
+        store.receive(.loading(.done(request, callback))) {
+            $0 = .loaded(.init(id: UUID(number: 1),
+                               request: request,
+                               handler: callback))
+        }
+    }
+    
+    func testLoadedConfirm() {
+        let callbackExpectation = expectation(description: "Expect callback to be called")
+        let request = EIDAuthenticationRequest.preview
+        
+        let callback: (FlaggedAttributes) -> Void = { attributes in
+            XCTAssertEqual(attributes, [.DG01: true, .DG02: true, .DG03: true, .DG04: true])
+            callbackExpectation.fulfill()
+        }
+        
+        let identifiableCallback = IdentifiableCallback(id: UUID(number: 0), callback: callback)
+        
+        let loadedState = IdentificationOverviewLoadedState(id: UUID(number: 0), request: request, handler: identifiableCallback)
+        let store = TestStore(
+            initialState: IdentificationOverviewState.loaded(loadedState),
+            reducer: identificationOverviewReducer,
+            environment: environment
+        )
+        
+        store.send(IdentificationOverviewAction.loaded(.confirm))
+        
+        wait(for: [callbackExpectation], timeout: 1.0)
+    }
+    
+    func testReceivePINCallback() {
+        let request = EIDAuthenticationRequest.preview
+        let callback: (FlaggedAttributes) -> Void = { attributes in
+            XCTFail("Should not be called")
+        }
+        
+        let identifiableCallback = IdentifiableCallback(id: UUID(number: 0), callback: callback)
+        
+        let loadedState = IdentificationOverviewLoadedState(id: UUID(number: 0), request: request, handler: identifiableCallback)
+        let store = TestStore(
+            initialState: IdentificationOverviewState.loaded(loadedState),
+            reducer: identificationOverviewReducer,
+            environment: environment
+        )
+        
+        let pinCallback: (String) -> Void = { _ in }
+        let identifiablePINCallback = PINCallback(id: UUID(number: 0), callback: pinCallback)
+        store.send(IdentificationOverviewAction.loaded(.idInteractionEvent(.success(.requestPIN(remainingAttempts: nil, pinCallback: pinCallback))))) {
+            let newLoadedState = IdentificationOverviewLoadedState(
+                id: UUID(number: 0),
+                request: request,
+                handler: identifiableCallback,
+                pinHandler: identifiablePINCallback
+            )
+            $0 = .loaded(newLoadedState)
+        }
+        
+        store.receive(.loaded(.callbackReceived(request, identifiablePINCallback)))
+    }
+    
+    func testCallingPINHandlerWhenConfirming() {
+        let request = EIDAuthenticationRequest.preview
+        
+        let callback: (FlaggedAttributes) -> Void = { attributes in
+            XCTFail("Should not be called")
+        }
+        
+        let identifiableCallback = IdentifiableCallback(id: UUID(number: 0), callback: callback)
+        
+        let pinCallback: (String) -> Void = { _ in }
+        let identifiablePINCallback = PINCallback(id: UUID(number: 0), callback: pinCallback)
+        
+        let loadedState = IdentificationOverviewLoadedState(
+            id: UUID(number: 0),
+            request: request,
+            handler: identifiableCallback,
+            pinHandler: identifiablePINCallback
+        )
+        let store = TestStore(
+            initialState: IdentificationOverviewState.loaded(loadedState),
+            reducer: identificationOverviewReducer,
+            environment: environment
+        )
+        
+        store.send(IdentificationOverviewAction.loaded(.confirm))
+        
+        store.receive(.loaded(.callbackReceived(request, identifiablePINCallback)))
     }
 }


### PR DESCRIPTION
…by reusing the pin handler we already got.