### PR TITLE
Use "Viewer" for CFBundleTypeRole

### DIFF
--- a/BundesIdent/Info.plist
+++ b/BundesIdent/Info.plist
@@ -6,7 +6,7 @@
 	<array>
 		<dict>
 			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
+			<string>Viewer</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>eid</string>


### PR DESCRIPTION
Changeset e3d89e2a introduced CFBundleTypeRole and CFBundleURLSchemes with "bundid". But changeset 85426020 switched it to "eid". Since "eid" is defined by the BSI (TR) this should be "Viewer" instead of "Editor".

https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app

  Choose a role for your app: either an editor role for URL schemes you define,
  or a viewer role for schemes your app adopts but doesn’t define.