### PR TITLE
Fix identification flow in preview app

### DIFF
--- a/BundesIdent/Managers/DebugIDInteractionManager.swift
+++ b/BundesIdent/Managers/DebugIDInteractionManager.swift
@@ -17,7 +17,7 @@ struct Card {
     var remainingAttempts: Int = 3
 }
 
-enum CancelAction {
+enum CancelAction: Equatable {
     case pin
     case can
 }


### PR DESCRIPTION
Missing equatable conformance lead to BAD ACCESS when trying to compare new Routes. 

Reproduce in `BundesIdent Preview`:
* 👆 So funktioniert’s 
* 👆 🔧
* 👆 requestAuthorization