### PR TITLE
Refactor CAN 1/2

### DIFF
--- a/BundesIdent.xcodeproj/project.pbxproj
+++ b/BundesIdent.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		E13F9E45288853950088E955 /* CoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13F9E44288853950088E955 /* CoordinatorTests.swift */; };
 		E144EBD628C63A31009B4900 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = E144EBD528C63A31009B4900 /* MarkdownUI */; };
 		E144EBD828C63A4D009B4900 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E144EBD728C63A4D009B4900 /* AboutView.swift */; };
+		E144F066299D012400C79E8B /* SharedCANScreens.swift in Sources */ = {isa = PBXBuildFile; fileRef = E144F065299D012400C79E8B /* SharedCANScreens.swift */; };
+		E144F068299D015800C79E8B /* SharedCANCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E144F067299D015800C79E8B /* SharedCANCoordinator.swift */; };
 		E149B15C2840F636002C1139 /* SetupScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E149B15B2840F636002C1139 /* SetupScanTests.swift */; };
 		E14C21B228B8BF9100192338 /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14C21B128B8BF9100192338 /* StorageManager.swift */; };
 		E156DD02287EF9C200C88914 /* XCUITestDeeplinking.swift in Sources */ = {isa = PBXBuildFile; fileRef = E156DD01287EF9C200C88914 /* XCUITestDeeplinking.swift */; };
@@ -259,6 +261,8 @@
 		E13F9E42288835350088E955 /* IdentificationCoordinatorStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentificationCoordinatorStateTests.swift; sourceTree = "<group>"; };
 		E13F9E44288853950088E955 /* CoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorTests.swift; sourceTree = "<group>"; };
 		E144EBD728C63A4D009B4900 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
+		E144F065299D012400C79E8B /* SharedCANScreens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedCANScreens.swift; sourceTree = "<group>"; };
+		E144F067299D015800C79E8B /* SharedCANCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedCANCoordinator.swift; sourceTree = "<group>"; };
 		E149B15B2840F636002C1139 /* SetupScanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupScanTests.swift; sourceTree = "<group>"; };
 		E14C21B128B8BF9100192338 /* StorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
 		E156DD01287EF9C200C88914 /* XCUITestDeeplinking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUITestDeeplinking.swift; sourceTree = "<group>"; };
@@ -585,6 +589,8 @@
 				E16708B4283D4F25001A1637 /* Screens.swift */,
 				E16708B2283D4ED2001A1637 /* SetupCoordinator.swift */,
 				E11EB2AC2853A8EA008B4042 /* SetupScreens.swift */,
+				E144F065299D012400C79E8B /* SharedCANScreens.swift */,
+				E144F067299D015800C79E8B /* SharedCANCoordinator.swift */,
 			);
 			path = TCA;
 			sourceTree = "<group>";
@@ -1160,6 +1166,7 @@
 				B9DF15642913CCF1004E15E9 /* SetupPersonalPinConfirm.swift in Sources */,
 				E1EFB5C42858EB0F005C38C6 /* IdentificationOverviewLoading.swift in Sources */,
 				E1F2F3D728770F28004C8D4B /* IdentifiableCallback.swift in Sources */,
+				E144F066299D012400C79E8B /* SharedCANScreens.swift in Sources */,
 				E1FFDF0C2875C7E9006DFE03 /* UUID+Zero.swift in Sources */,
 				E1AB87A4282413A700C7FC94 /* PINTextField.swift in Sources */,
 				E11EB2AD2853A8EA008B4042 /* SetupScreens.swift in Sources */,
@@ -1198,6 +1205,7 @@
 				B95FAA8B2927A90D009BDAC9 /* CANIncorrectInput.swift in Sources */,
 				E1CD8E9528215971008ADA2A /* PINEntryView.swift in Sources */,
 				E1B0F5A62981435C00143B82 /* SetupCANConfirmTransportPIN.swift in Sources */,
+				E144F068299D015800C79E8B /* SharedCANCoordinator.swift in Sources */,
 				E13925B82840FB7700161F5C /* Types.swift in Sources */,
 				E13925C72841119400161F5C /* MockIDInteractionManager.swift in Sources */,
 				E1BC3D7928B7E40B007A7B39 /* LicensesView.swift in Sources */,

--- a/BundesIdent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BundesIdent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "c3a42e8d1a76ff557cf565ed6d8b0aee0e6e75af",
-        "version" : "0.11.0"
+        "revision" : "3c4eea896f8ee9cbe1c11d1d3d46b0f2809da958",
+        "version" : "0.12.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "6cf778a7da64de9508596a435aa0a5647885d71a",
-        "version" : "0.49.2"
+        "revision" : "1b998c43b3b3505876db6f66e03243dd2453e93a",
+        "version" : "0.50.3"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "ead7d30cc224c3642c150b546f4f1080d1c411a8",
-        "version" : "0.6.1"
+        "revision" : "dd86159e25c749873f144577e5d18309bf57534f",
+        "version" : "0.8.0"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "fd34c544ad27f3ba6b19142b348005bfa85b6005",
-        "version" : "0.6.0"
+        "revision" : "ad3932d28c2e0a009a0167089619526709ef6497",
+        "version" : "0.7.0"
       }
     },
     {
@@ -167,17 +167,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "ddc01cdcddfd30ef7a966049b2e1d251e224ad93",
-        "version" : "0.5.0"
+        "revision" : "270a754308f5440be52fc295242eb7031638bd15",
+        "version" : "0.6.1"
       }
     },
     {
       "identity" : "tcacoordinators",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/johnpatrickmorgan/TCACoordinators.git",
+      "location" : "https://github.com/johnpatrickmorgan/TCACoordinators",
       "state" : {
-        "revision" : "b94764ca74de5acca169c1c1c458ddab5e43de45",
-        "version" : "0.3.0"
+        "revision" : "18e2707ff569a111f415915de1972316b3f256a2",
+        "version" : "0.4.0"
       }
     },
     {
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "16b23a295fa322eb957af98037f86791449de60f",
-        "version" : "0.8.1"
+        "revision" : "62041e6016a30f56952f5d7d3f12a3fd7029e1cd",
+        "version" : "0.8.3"
       }
     }
   ],

--- a/BundesIdent/Managers/ChangePINDebugSequence.swift
+++ b/BundesIdent/Managers/ChangePINDebugSequence.swift
@@ -65,7 +65,6 @@ enum ChangePINDebugSequence: Identifiable, Equatable {
                     .runCardBlocked
                 ]
             } else {
-                // TODO: PUK, need investigation
                 return []
             }
         case .changePINSuccessfully:

--- a/BundesIdent/Managers/DebugIDInteractionManager.swift
+++ b/BundesIdent/Managers/DebugIDInteractionManager.swift
@@ -17,11 +17,6 @@ struct Card {
     var remainingAttempts: Int = 3
 }
 
-enum CancelAction: Equatable {
-    case pin
-    case can
-}
-
 class DebugIDInteractionManager: IDInteractionManagerType {
     private var subject: PassthroughSubject<EIDInteractionEvent, IDCardInteractionError>?
     private var card: Card = .init(remainingAttempts: 3)

--- a/BundesIdent/TCA/Coordinator.swift
+++ b/BundesIdent/TCA/Coordinator.swift
@@ -141,20 +141,16 @@ struct Coordinator: ReducerProtocol {
                 return Effect(value: .openURL(tokenURL))
 #endif
             case .identificationCoordinator(.dismiss),
-                 .identificationCoordinator(.routeAction(_, action: .identificationCANCoordinator(.dismiss))),
                  .identificationCoordinator(.afterConfirmEnd),
-                 .identificationCoordinator(.routeAction(_, action: .identificationCANCoordinator(.afterConfirmEnd))),
                  .identificationCoordinator(.routeAction(_, action: .scan(.dismiss))),
+                 .identificationCoordinator(.routeAction(_, action: .identificationCANCoordinator(.dismiss))), // TODO: Lift up all under CAN
+                 .identificationCoordinator(.routeAction(_, action: .identificationCANCoordinator(.afterConfirmEnd))),
                  .identificationCoordinator(.routeAction(_, action: .identificationCANCoordinator(.routeAction(_, action: .canScan(.dismiss))))),
                  .setupCoordinator(.confirmEnd),
                  .setupCoordinator(.routeAction(_, action: .done(.done))),
-                 .setupCoordinator(.routeAction(_, action: .setupCANCoordinator(.routeAction(_, action: .canAlreadySetup(.done))))),
                  .setupCoordinator(.routeAction(_, action: .setupCANCoordinator(.dismiss))),
                  .setupCoordinator(.routeAction(_, action: .setupCANCoordinator(.routeAction(_, action: .canScan(.dismiss))))),
-                 .setupCoordinator(.afterConfirmEnd),
-                 // This is bad, but we can not switch back to a previous coordinator while having another coordinator inbetween. See https://github.com/johnpatrickmorgan/FlowStacks/issues/23#issuecomment-1407125421
-                 // We are only showing the setup coordinator in the end for the done screen
-                 .setupCoordinator(.routeAction(_, action: .setupCANCoordinator(.routeAction(_, action: .setupCoordinator(.routeAction(_, action: .done(.done))))))):
+                 .setupCoordinator(.afterConfirmEnd):
                 state.routes.dismiss()
                 return .none
             default:

--- a/BundesIdent/TCA/IdentificationCANCoordinator.swift
+++ b/BundesIdent/TCA/IdentificationCANCoordinator.swift
@@ -6,14 +6,6 @@ import SwiftUI
 import ComposableArchitecture
 import Analytics
 
-enum IdentificationCANCoordinatorError: CustomNSError {
-    case canNilWhenTriedScan
-    case pinNilWhenTriedScan
-    case canIntroStateNotInRoutes
-    case pinCANCallbackNilWhenTriedScan
-    case noScreenToHandleEIDInteractionEvents
-}
-
 struct IdentificationCANCoordinator: ReducerProtocol {
     @Dependency(\.issueTracker) var issueTracker
     @Dependency(\.logger) var logger
@@ -89,7 +81,7 @@ struct IdentificationCANCoordinator: ReducerProtocol {
                                                              shared: SharedScan.State(showInstructions: false)))
                     )
                 } else {
-                    issueTracker.capture(error: IdentificationCANCoordinatorError.pinNilWhenTriedScan)
+                    issueTracker.capture(error: SharedCANCoordinatorError.pinNilWhenTriedScan)
                     logger.error("PIN nil when tried to scan")
                     return Effect(value: .dismiss)
                 }
@@ -97,7 +89,7 @@ struct IdentificationCANCoordinator: ReducerProtocol {
             case .routeAction(_, action: .canPersonalPINInput(.done(pin: let pin))):
                 state.pin = pin
                 guard let can = state.can else {
-                    issueTracker.capture(error: IdentificationCANCoordinatorError.canNilWhenTriedScan)
+                    issueTracker.capture(error: SharedCANCoordinatorError.canNilWhenTriedScan)
                     logger.error("CAN nil when tried to scan")
                     return Effect(value: .dismiss)
                 }
@@ -116,7 +108,7 @@ struct IdentificationCANCoordinator: ReducerProtocol {
                     }
                     return false
                 }) else {
-                    issueTracker.capture(error: IdentificationCANCoordinatorError.canIntroStateNotInRoutes)
+                    issueTracker.capture(error: SharedCANCoordinatorError.canIntroStateNotInRoutes)
                     logger.error("CanIntroState not found in routes")
                     return Effect(value: .dismiss)
                 }

--- a/BundesIdent/TCA/IdentificationCANCoordinator.swift
+++ b/BundesIdent/TCA/IdentificationCANCoordinator.swift
@@ -62,10 +62,10 @@ struct IdentificationCANCoordinator: ReducerProtocol {
                 state.routes.push(.canOrderNewPIN(.init()))
                 return .none
             case .routeAction(_, action: .canPINForgotten(.showCANIntro)):
-                state.routes.push(.canIntro(CANIntro.State(shouldDismiss: false)))
+                state.routes.push(.canIntro(CANIntro.State(isRootOfCANFlow: false)))
                 return .none
-            case .routeAction(_, action: .canIntro(.showInput(let shouldDismiss))):
-                state.routes.push(.canInput(CANInput.State(pushesToPINEntry: !shouldDismiss)))
+            case .routeAction(_, action: .canIntro(.showInput(let isRootOfCANFlow))):
+                state.routes.push(.canInput(CANInput.State(pushesToPINEntry: !isRootOfCANFlow)))
                 return .none
             case .routeAction(_, action: .canIntro(.end)):
                 return Effect(value: .swipeToDismiss)
@@ -182,7 +182,7 @@ extension IdentificationCANCoordinator.State {
         self.tokenURL = tokenURL
         self.attempt = attempt
         if goToCanIntroScreen {
-            states = [.root(.canIntro(.init(shouldDismiss: true)))]
+            states = [.root(.canIntro(.init(isRootOfCANFlow: true)))]
         } else {
             states = [.root(.canPINForgotten(.init()))]
         }

--- a/BundesIdent/TCA/IdentificationCANScreen.swift
+++ b/BundesIdent/TCA/IdentificationCANScreen.swift
@@ -30,7 +30,7 @@ struct IdentificationCANScreen: ReducerProtocol {
             case .canPINForgotten: return .allowAfterConfirmation()
             case .canOrderNewPIN: return .block
             case .canIntro(let state):
-                return state.shouldDismiss ? .allowAfterConfirmation() : .block
+                return state.isRootOfCANFlow ? .allowAfterConfirmation() : .block
             case .canInput: return .block
             case .canPersonalPINInput: return .block
             case .canIncorrectInput: return .allowAfterConfirmation()

--- a/BundesIdent/TCA/SetupCANCoordinator.swift
+++ b/BundesIdent/TCA/SetupCANCoordinator.swift
@@ -149,10 +149,10 @@ struct SetupCANCoordinator: ReducerProtocol {
                 state.routes.push(.setupCoordinator(setupCoordinatorState))
                 return .none
             case .routeAction(_, action: .canScan(.error(let errorState))):
-                state.routes.presentSheet(.shared(.error(errorState)))
+                state.routes.presentSheet(.shared(.scanError(errorState)))
                 return .none
             case .routeAction(_, action: .canScan(.shared(.showHelp))):
-                state.routes.presentSheet(.shared(.error(ScanError.State(errorType: .help, retry: true))))
+                state.routes.presentSheet(.shared(.scanError(ScanError.State(errorType: .help, retry: true))))
                 return .none
                 
             case .shared(.afterConfirmEnd),
@@ -299,7 +299,7 @@ struct SharedCANScreenView: View {
             CaseLet(state: /SharedCANScreen.State.canIncorrectInput,
                     action: SharedCANScreen.Action.canIncorrectInput,
                     then: CANIncorrectInputView.init)
-            CaseLet(state: /SharedCANScreen.State.error,
+            CaseLet(state: /SharedCANScreen.State.scanError,
                     action: SharedCANScreen.Action.error,
                     then: ScanErrorView.init)
         }

--- a/BundesIdent/TCA/SetupCANCoordinator.swift
+++ b/BundesIdent/TCA/SetupCANCoordinator.swift
@@ -84,7 +84,7 @@ struct SetupCANCoordinator: ReducerProtocol {
                 state.routes.push(.canAlreadySetup(.init(tokenURL: state.tokenURL)))
                 return .none
             case .routeAction(_, action: .canConfirmTransportPIN(.edit)):
-                state.routes.push(.shared(.canIntro(.init(shouldDismiss: false))))
+                state.routes.push(.shared(.canIntro(.init(isRootOfCANFlow: false))))
                 return .none
             case .routeAction(_, action: .canAlreadySetup(.missingPersonalPIN)):
                 state.routes.push(.missingPIN(.init()))
@@ -199,7 +199,7 @@ extension SetupCANCoordinator.State {
         _shared = .init(attempt: attempt)
         
         if goToCanIntroScreen {
-            states = [.root(.shared(.canIntro(.init(shouldDismiss: true))))]
+            states = [.root(.shared(.canIntro(.init(isRootOfCANFlow: true))))]
         } else {
             states = [
                 .root(.canConfirmTransportPIN(SetupCANConfirmTransportPIN.State(transportPIN: oldTransportPIN)))

--- a/BundesIdent/TCA/SetupCANScreens.swift
+++ b/BundesIdent/TCA/SetupCANScreens.swift
@@ -34,10 +34,9 @@ struct SetupCANScreen: ReducerProtocol {
             case .setupCoordinator(let state):
                 guard let localAction = state.transformToLocalAction(event) else { return nil }
                 return .setupCoordinator(localAction)
-            // TODO:
-//            case .shared(let state):
-//                guard let localAction = state.transformToLocalAction(event) else { return nil }
-//                return .shared(localAction)
+            case .shared(let state):
+                guard let localAction = state.transformToLocalAction(event) else { return nil }
+                return .shared(localAction)
             default:
                 return nil
             }

--- a/BundesIdent/TCA/SetupCANScreens.swift
+++ b/BundesIdent/TCA/SetupCANScreens.swift
@@ -9,27 +9,20 @@ struct SetupCANScreen: ReducerProtocol {
         case canAlreadySetup(SetupCANAlreadySetup.State)
         case canConfirmTransportPIN(SetupCANConfirmTransportPIN.State)
         case missingPIN(MissingPINLetter.State)
-        case canIntro(CANIntro.State)
-        case canInput(CANInput.State)
         case canTransportPINInput(SetupTransportPIN.State)
         case canScan(SetupCANScan.State)
-        case canIncorrectInput(CANIncorrectInput.State)
-        case error(ScanError.State)
         case setupCoordinator(SetupCoordinator.State)
+        case shared(SharedCANScreen.State)
         
         var swipeToDismissState: SwipeToDismissState {
             switch self {
             case .canConfirmTransportPIN: return .allowAfterConfirmation()
             case .canAlreadySetup: return .block
             case .missingPIN: return .block
-            case .canIntro(let state):
-                return state.shouldDismiss ? .allowAfterConfirmation() : .block
-            case .canInput: return .block
             case .canTransportPINInput: return .block
             case .canScan: return .block
-            case .canIncorrectInput: return .allowAfterConfirmation()
-            case .error: return .allow
             case .setupCoordinator: return .allow
+            case .shared(let state): return state.swipeToDismissState
             }
         }
         
@@ -41,23 +34,24 @@ struct SetupCANScreen: ReducerProtocol {
             case .setupCoordinator(let state):
                 guard let localAction = state.transformToLocalAction(event) else { return nil }
                 return .setupCoordinator(localAction)
+            // TODO:
+//            case .shared(let state):
+//                guard let localAction = state.transformToLocalAction(event) else { return nil }
+//                return .shared(localAction)
             default:
                 return nil
             }
         }
     }
     
-    enum Action: Equatable {
+    indirect enum Action: Equatable {
         case canAlreadySetup(SetupCANAlreadySetup.Action)
         case canConfirmTransportPIN(SetupCANConfirmTransportPIN.Action)
         case missingPIN(MissingPINLetter.Action)
-        case canIntro(CANIntro.Action)
-        case canInput(CANInput.Action)
         case canTransportPINInput(SetupTransportPIN.Action)
         case canScan(SetupCANScan.Action)
-        case canIncorrectInput(CANIncorrectInput.Action)
-        case error(ScanError.Action)
         case setupCoordinator(SetupCoordinator.Action)
+        case shared(SharedCANScreen.Action)
     }
     
     var body: some ReducerProtocol<State, Action> {
@@ -70,26 +64,17 @@ struct SetupCANScreen: ReducerProtocol {
         Scope(state: /State.missingPIN, action: /Action.missingPIN) {
             MissingPINLetter()
         }
-        Scope(state: /State.canIntro, action: /Action.canIntro) {
-            CANIntro()
-        }
-        Scope(state: /State.canInput, action: /Action.canInput) {
-            CANInput()
-        }
         Scope(state: /State.canTransportPINInput, action: /Action.canTransportPINInput) {
             SetupTransportPIN()
         }
         Scope(state: /State.canScan, action: /Action.canScan) {
             SetupCANScan()
         }
-        Scope(state: /State.canIncorrectInput, action: /Action.canIncorrectInput) {
-            CANIncorrectInput()
-        }
-        Scope(state: /State.error, action: /Action.error) {
-            ScanError()
-        }
         Scope(state: /State.setupCoordinator, action: /Action.setupCoordinator) {
             SetupCoordinator()
+        }
+        Scope(state: /State.shared, action: /Action.shared) {
+            SharedCANScreen()
         }
     }
 }
@@ -103,19 +88,13 @@ extension SetupCANScreen.State: AnalyticsView {
             return ["canAlreadySetup"]
         case .missingPIN:
             return ["canMissingPIN"]
-        case .canIntro:
-            return ["canIntro"]
-        case .canInput:
-            return ["canInput"]
         case .canTransportPINInput:
             return ["canTransportPINInput"]
         case .canScan:
             return ["canScan"]
-        case .canIncorrectInput:
-            return ["canIncorrectInput"]
-        case .error(let state):
-            return state.errorType.route
         case .setupCoordinator(let state):
+            return state.route
+        case .shared(let state):
             return state.route
         }
     }

--- a/BundesIdent/TCA/SharedCANCoordinator.swift
+++ b/BundesIdent/TCA/SharedCANCoordinator.swift
@@ -1,0 +1,83 @@
+import Foundation
+import ComposableArchitecture
+
+enum SharedCANCoordinatorError: CustomNSError {
+    case canNilWhenTriedScan
+    case pinNilWhenTriedScan
+    case canIntroStateNotInRoutes
+    case pinCANCallbackNilWhenTriedScan
+    case noScreenToHandleEIDInteractionEvents
+}
+
+struct SharedCANCoordinator: ReducerProtocol {
+    
+    @Dependency(\.issueTracker) var issueTracker
+    @Dependency(\.logger) var logger
+    @Dependency(\.mainQueue) var mainQueue
+    
+    struct State: Equatable {
+        var pin: String?
+        var can: String?
+        var authenticationSuccessful = false
+        var attempt: Int
+        var alert: AlertState<Action>?
+        var swipeToDismiss: SwipeToDismissState = .allow // TODO: Get from parent?
+    }
+    
+    enum Action: Equatable {
+        case swipeToDismiss
+        case routeAction(Int, action: SharedCANScreen.Action)
+        case push(SharedCANScreen.State)
+        case dismiss
+        case dismissAlert
+        case afterConfirmEnd
+    }
+    
+    var body: some ReducerProtocol<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .routeAction(_, action: .canIntro(.showInput(let shouldDismiss))):
+                return Effect(value: .push(.canInput(CANInput.State(pushesToPINEntry: !shouldDismiss))))
+            case .routeAction(_, action: .canIntro(.end)):
+                return Effect(value: .swipeToDismiss)
+            case .routeAction(_, action: .canIncorrectInput(.done(can: let newCAN))):
+                state.can = newCAN
+                state.attempt += 1
+                return Effect(value: .dismiss)
+            case .routeAction(_, action: .canInput(.done(can: let can, pushesToPINEntry: _))):
+                state.can = can
+                return .none
+            case .routeAction(_, action: .error(.retry)):
+                return Effect(value: .dismiss)
+            case .routeAction(_, action: .error(.end)):
+                return EffectTask.concatenate(
+                    Effect(value: .dismiss),
+                    // Dismissing two sheets at the same time from different coordinators is not well supported.
+                    // Waiting for 0.65s (as TCACoordinators does) fixes this temporarily.
+                    Effect(value: .afterConfirmEnd)
+                        .delay(for: 0.65, scheduler: mainQueue)
+                        .eraseToEffect()
+                )
+            case .swipeToDismiss:
+                switch state.swipeToDismiss {
+                case .allow:
+                    return .none
+                case .block:
+                    return .none
+                case .allowAfterConfirmation:
+                    state.alert = AlertState(title: TextState(verbatim: L10n.Identification.ConfirmEnd.title),
+                                             message: TextState(verbatim: L10n.Identification.ConfirmEnd.message),
+                                             primaryButton: .destructive(TextState(verbatim: L10n.Identification.ConfirmEnd.confirm),
+                                                                         action: .send(.dismiss)),
+                                             secondaryButton: .cancel(TextState(verbatim: L10n.Identification.ConfirmEnd.deny)))
+                    return .none
+                }
+            case .dismissAlert:
+                state.alert = nil
+                return .none
+            default:
+                return .none
+            }
+        }
+    }
+}

--- a/BundesIdent/TCA/SharedCANCoordinator.swift
+++ b/BundesIdent/TCA/SharedCANCoordinator.swift
@@ -36,8 +36,8 @@ struct SharedCANCoordinator: ReducerProtocol {
     var body: some ReducerProtocol<State, Action> {
         Reduce { state, action in
             switch action {
-            case .routeAction(_, action: .canIntro(.showInput(let shouldDismiss))):
-                return Effect(value: .push(.canInput(CANInput.State(pushesToPINEntry: !shouldDismiss))))
+            case .routeAction(_, action: .canIntro(.showInput(let isRootOfCANFlow))):
+                return Effect(value: .push(.canInput(CANInput.State(pushesToPINEntry: !isRootOfCANFlow))))
             case .routeAction(_, action: .canIntro(.end)):
                 return Effect(value: .swipeToDismiss)
             case .routeAction(_, action: .canIncorrectInput(.done(can: let newCAN))):

--- a/BundesIdent/TCA/SharedCANScreens.swift
+++ b/BundesIdent/TCA/SharedCANScreens.swift
@@ -1,0 +1,58 @@
+import Foundation
+import ComposableArchitecture
+import Analytics
+
+struct SharedCANScreen: ReducerProtocol {
+    enum State: Equatable {
+        case canIntro(CANIntro.State)
+        case canInput(CANInput.State)
+        case canIncorrectInput(CANIncorrectInput.State)
+        case error(ScanError.State) // TODO: Rename case to scanError
+        
+        var swipeToDismissState: SwipeToDismissState {
+            switch self {
+            case .canIntro(let state): return state.shouldDismiss ? .allowAfterConfirmation() : .block
+            case .canInput: return .block
+            case .canIncorrectInput: return .allowAfterConfirmation()
+            case .error: return .allow
+            }
+        }
+    }
+    
+    enum Action: Equatable {
+        case canIntro(CANIntro.Action)
+        case canInput(CANInput.Action)
+        case canIncorrectInput(CANIncorrectInput.Action)
+        case error(ScanError.Action)
+    }
+    
+    var body: some ReducerProtocol<State, Action> {
+        Scope(state: /State.canIntro, action: /Action.canIntro) {
+            CANIntro()
+        }
+        Scope(state: /State.canInput, action: /Action.canInput) {
+            CANInput()
+        }
+        Scope(state: /State.canIncorrectInput, action: /Action.canIncorrectInput) {
+            CANIncorrectInput()
+        }
+        Scope(state: /State.error, action: /Action.error) {
+            ScanError()
+        }
+    }
+}
+
+extension SharedCANScreen.State: AnalyticsView {
+    var route: [String] {
+        switch self {
+        case .canIntro:
+            return ["canIntro"]
+        case .canInput:
+            return ["canInput"]
+        case .canIncorrectInput:
+            return ["canIncorrectInput"]
+        case .error(let state):
+            return state.errorType.route
+        }
+    }
+}

--- a/BundesIdent/TCA/SharedCANScreens.swift
+++ b/BundesIdent/TCA/SharedCANScreens.swift
@@ -11,7 +11,7 @@ struct SharedCANScreen: ReducerProtocol {
         
         var swipeToDismissState: SwipeToDismissState {
             switch self {
-            case .canIntro(let state): return state.shouldDismiss ? .allowAfterConfirmation() : .block
+            case .canIntro(let state): return state.isRootOfCANFlow ? .allowAfterConfirmation() : .block
             case .canInput: return .block
             case .canIncorrectInput: return .allowAfterConfirmation()
             case .scanError: return .allow

--- a/BundesIdent/TCA/SharedCANScreens.swift
+++ b/BundesIdent/TCA/SharedCANScreens.swift
@@ -17,6 +17,13 @@ struct SharedCANScreen: ReducerProtocol {
             case .scanError: return .allow
             }
         }
+        
+        func transformToLocalAction(_ event: Result<EIDInteractionEvent, IDCardInteractionError>) -> Action? {
+            switch self {
+            default:
+                return nil
+            }
+        }
     }
     
     enum Action: Equatable {

--- a/BundesIdent/TCA/SharedCANScreens.swift
+++ b/BundesIdent/TCA/SharedCANScreens.swift
@@ -7,14 +7,14 @@ struct SharedCANScreen: ReducerProtocol {
         case canIntro(CANIntro.State)
         case canInput(CANInput.State)
         case canIncorrectInput(CANIncorrectInput.State)
-        case error(ScanError.State) // TODO: Rename case to scanError
+        case scanError(ScanError.State)
         
         var swipeToDismissState: SwipeToDismissState {
             switch self {
             case .canIntro(let state): return state.shouldDismiss ? .allowAfterConfirmation() : .block
             case .canInput: return .block
             case .canIncorrectInput: return .allowAfterConfirmation()
-            case .error: return .allow
+            case .scanError: return .allow
             }
         }
     }
@@ -36,7 +36,7 @@ struct SharedCANScreen: ReducerProtocol {
         Scope(state: /State.canIncorrectInput, action: /Action.canIncorrectInput) {
             CANIncorrectInput()
         }
-        Scope(state: /State.error, action: /Action.error) {
+        Scope(state: /State.scanError, action: /Action.error) {
             ScanError()
         }
     }
@@ -51,7 +51,7 @@ extension SharedCANScreen.State: AnalyticsView {
             return ["canInput"]
         case .canIncorrectInput:
             return ["canIncorrectInput"]
-        case .error(let state):
+        case .scanError(let state):
             return state.errorType.route
         }
     }

--- a/BundesIdent/Views/Setup/SetupDone.swift
+++ b/BundesIdent/Views/Setup/SetupDone.swift
@@ -38,7 +38,7 @@ struct SetupDoneView: View {
                        primaryButton: viewStore.primaryButton)
         }
         .navigationBarBackButtonHidden(true)
-        .navigationBarHidden(false)
+        .navigationBarHidden(true)
         .interactiveDismissDisabled()
     }
     

--- a/BundesIdent/Views/Shared CAN/CANIntro.swift
+++ b/BundesIdent/Views/Shared CAN/CANIntro.swift
@@ -3,11 +3,11 @@ import ComposableArchitecture
 
 struct CANIntro: ReducerProtocol {
     struct State: Equatable {
-        var shouldDismiss: Bool // TODO: Rename to isRootOfCANFlow
+        var isRootOfCANFlow: Bool
     }
     
     enum Action: Equatable {
-        case showInput(shouldDismiss: Bool)
+        case showInput(isRootOfCANFlow: Bool)
         case end
     }
     
@@ -23,10 +23,10 @@ struct CANIntroView: View {
             DialogView(store: store.stateless, title: L10n.Identification.Can.Intro.title,
                        message: L10n.Identification.Can.Intro.body,
                        imageMeta: ImageMeta(asset: Asset.idCan),
-                       primaryButton: .init(title: L10n.Identification.Can.Intro.continue, action: .showInput(shouldDismiss: viewStore.shouldDismiss)))
+                       primaryButton: .init(title: L10n.Identification.Can.Intro.continue, action: .showInput(isRootOfCANFlow: viewStore.isRootOfCANFlow)))
             
-                .navigationBarBackButtonHidden(viewStore.shouldDismiss)
-                .navigationBarItems(leading: viewStore.shouldDismiss ? cancelButton(viewStore: viewStore) : nil)
+                .navigationBarBackButtonHidden(viewStore.isRootOfCANFlow)
+                .navigationBarItems(leading: viewStore.isRootOfCANFlow ? cancelButton(viewStore: viewStore) : nil)
         }
     }
     
@@ -44,7 +44,7 @@ struct CANIntroView: View {
 struct CANIntro_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            CANIntroView(store: .init(initialState: .init(shouldDismiss: true),
+            CANIntroView(store: .init(initialState: .init(isRootOfCANFlow: true),
                                       reducer: CANIntro()))
         }
         .previewDevice("iPhone 12")

--- a/BundesIdent/Views/Shared CAN/CANIntro.swift
+++ b/BundesIdent/Views/Shared CAN/CANIntro.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 
 struct CANIntro: ReducerProtocol {
     struct State: Equatable {
-        var shouldDismiss: Bool
+        var shouldDismiss: Bool // TODO: Rename to isRootOfCANFlow
     }
     
     enum Action: Equatable {

--- a/BundesIdentTests/TCA/IdentificationCANCoordinatorTests.swift
+++ b/BundesIdentTests/TCA/IdentificationCANCoordinatorTests.swift
@@ -51,12 +51,12 @@ class IdentificationCANCoordinatorTests: XCTestCase {
                                                              tokenURL: demoTokenURL,
                                                              attempt: 0,
                                                              states: [
-                                                                 .root(.canIntro(CANIntro.State(shouldDismiss: true)))
+                                                                 .root(.canIntro(CANIntro.State(isRootOfCANFlow: true)))
                                                              ]),
             reducer: IdentificationCANCoordinator()
         )
         
-        store.send(.routeAction(0, action: .canIntro(.showInput(shouldDismiss: true)))) {
+        store.send(.routeAction(0, action: .canIntro(.showInput(isRootOfCANFlow: true)))) {
             $0.routes.append(.push(.canInput(CANInput.State(pushesToPINEntry: false))))
         }
         
@@ -146,7 +146,7 @@ class IdentificationCANCoordinatorTests: XCTestCase {
         let newPINCANCallback = PINCANCallback(id: UUID(number: 1), callback: { _, _ in })
         
         let oldRoutes: [Route<IdentificationCANScreen.State>] = [
-            .root(.canIntro(CANIntro.State(shouldDismiss: true))),
+            .root(.canIntro(CANIntro.State(isRootOfCANFlow: true))),
             .push(.canInput(CANInput.State(pushesToPINEntry: false))),
             .push(.canScan(IdentificationCANScan.State(pin: pin, can: can, pinCANCallback: newPINCANCallback, shared: SharedScan.State(showInstructions: false)))),
             .sheet(.canIncorrectInput(CANIncorrectInput.State()))
@@ -168,7 +168,7 @@ class IdentificationCANCoordinatorTests: XCTestCase {
         let routesWithSheetDismissed = Array(oldRoutes.dropLast(1))
     
         let updatedRoutes: [Route<IdentificationCANScreen.State>] = [
-            .sheet(.canIntro(CANIntro.State(shouldDismiss: true)))
+            .sheet(.canIntro(CANIntro.State(isRootOfCANFlow: true)))
         ]
         
         store.send(.routeAction(3, action: .canIncorrectInput(.end)))

--- a/BundesIdentTests/TCA/RouteTests.swift
+++ b/BundesIdentTests/TCA/RouteTests.swift
@@ -355,7 +355,7 @@ final class RouteTests: XCTestCase {
         verify(mockMatomoTracker).reset()
         endInteraction(mockMatomoTracker)
 
-        store.send(.routeAction(1, action: .identificationCoordinator(.routeAction(3, action: .identificationCANCoordinator(.routeAction(1, action: .canIntro(.showInput(shouldDismiss: true))))))))
+        store.send(.routeAction(1, action: .identificationCoordinator(.routeAction(3, action: .identificationCANCoordinator(.routeAction(1, action: .canIntro(.showInput(isRootOfCANFlow: true))))))))
         verify(mockMatomoTracker).track(view: ["identification", "canInput"],
                                         url: URL?.none)
         endInteraction(mockMatomoTracker)

--- a/BundesIdentTests/TCA/SetupCANCoordinatorTests.swift
+++ b/BundesIdentTests/TCA/SetupCANCoordinatorTests.swift
@@ -24,12 +24,12 @@ class SetupCANCoordinatorTests: XCTestCase {
                                                         attempt: 0
                                                     ),
                                                     states: [
-                                                        .root(.shared(.canIntro(CANIntro.State(shouldDismiss: true))))
+                                                        .root(.shared(.canIntro(CANIntro.State(isRootOfCANFlow: true))))
                                                     ]),
             reducer: SetupCANCoordinator()
         )
         
-        store.send(.routeAction(0, action: .shared(.canIntro(.showInput(shouldDismiss: true))))) {
+        store.send(.routeAction(0, action: .shared(.canIntro(.showInput(isRootOfCANFlow: true))))) {
             $0.shared.swipeToDismiss = SwipeToDismissState.allowAfterConfirmation(
                 title: L10n.Identification.ConfirmEnd.title,
                 body: L10n.Identification.ConfirmEnd.message,
@@ -74,12 +74,12 @@ class SetupCANCoordinatorTests: XCTestCase {
                                                         attempt: 0
                                                     ),
                                                     states: [
-                                                        .root(.shared(.canIntro(CANIntro.State(shouldDismiss: true))))
+                                                        .root(.shared(.canIntro(CANIntro.State(isRootOfCANFlow: true))))
                                                     ]),
             reducer: SetupCANCoordinator()
         )
         
-        store.send(.routeAction(0, action: .shared(.canIntro(.showInput(shouldDismiss: false))))) {
+        store.send(.routeAction(0, action: .shared(.canIntro(.showInput(isRootOfCANFlow: false))))) {
             $0.shared.swipeToDismiss = SwipeToDismissState.allowAfterConfirmation(
                 title: L10n.Identification.ConfirmEnd.title,
                 body: L10n.Identification.ConfirmEnd.message,

--- a/BundesIdentTests/TCA/SetupCANCoordinatorTests.swift
+++ b/BundesIdentTests/TCA/SetupCANCoordinatorTests.swift
@@ -20,19 +20,30 @@ class SetupCANCoordinatorTests: XCTestCase {
                                                     oldTransportPIN: transportPIN,
                                                     canAndChangedPINCallback: canAndChangedPINCallback,
                                                     tokenURL: demoTokenURL,
-                                                    attempt: 0,
+                                                    _shared: SharedCANCoordinator.State(
+                                                        attempt: 0
+                                                    ),
                                                     states: [
-                                                        .root(.canIntro(CANIntro.State(shouldDismiss: true)))
+                                                        .root(.shared(.canIntro(CANIntro.State(shouldDismiss: true))))
                                                     ]),
             reducer: SetupCANCoordinator()
         )
         
-        store.send(.routeAction(0, action: .canIntro(.showInput(shouldDismiss: true)))) {
-            $0.routes.append(.push(.canInput(CANInput.State(pushesToPINEntry: false))))
+        store.send(.routeAction(0, action: .shared(.canIntro(.showInput(shouldDismiss: true))))) {
+            $0.shared.swipeToDismiss = SwipeToDismissState.allowAfterConfirmation(
+                title: L10n.Identification.ConfirmEnd.title,
+                body: L10n.Identification.ConfirmEnd.message,
+                confirm: L10n.Identification.ConfirmEnd.confirm,
+                deny: L10n.General.cancel
+            )
         }
         
-        store.send(.routeAction(1, action: .canInput(.done(can: can, pushesToPINEntry: false)))) {
-            $0.can = can
+        store.receive(.shared(.push(.canInput(CANInput.State(pushesToPINEntry: false))))) {
+            $0.routes.append(.push(.shared(.canInput(CANInput.State(pushesToPINEntry: false)))))
+        }
+        
+        store.send(.routeAction(1, action: .shared(.canInput(.done(can: can, pushesToPINEntry: false))))) {
+            $0.shared.can = can
             $0.routes.append(.push(
                 .canScan(SetupCANScan.State(transportPIN: transportPIN,
                                             newPIN: pin,
@@ -44,7 +55,7 @@ class SetupCANCoordinatorTests: XCTestCase {
         
         store.send(.routeAction(2, action: .canScan(.incorrectCAN(callback: newCANAndChangedPINCallback)))) {
             $0.canAndChangedPINCallback = newCANAndChangedPINCallback
-            $0.routes.append(.sheet(.canIncorrectInput(.init())))
+            $0.routes.append(.sheet(.shared(.canIncorrectInput(.init()))))
         }
     }
     
@@ -59,19 +70,30 @@ class SetupCANCoordinatorTests: XCTestCase {
                                                     oldTransportPIN: transportPIN,
                                                     canAndChangedPINCallback: canAndChangedPINCallback,
                                                     tokenURL: demoTokenURL,
-                                                    attempt: 0,
+                                                    _shared: SharedCANCoordinator.State(
+                                                        attempt: 0
+                                                    ),
                                                     states: [
-                                                        .root(.canIntro(CANIntro.State(shouldDismiss: true)))
+                                                        .root(.shared(.canIntro(CANIntro.State(shouldDismiss: true))))
                                                     ]),
             reducer: SetupCANCoordinator()
         )
         
-        store.send(.routeAction(0, action: .canIntro(.showInput(shouldDismiss: false)))) {
-            $0.routes.append(.push(.canInput(CANInput.State(pushesToPINEntry: true))))
+        store.send(.routeAction(0, action: .shared(.canIntro(.showInput(shouldDismiss: false))))) {
+            $0.shared.swipeToDismiss = SwipeToDismissState.allowAfterConfirmation(
+                title: L10n.Identification.ConfirmEnd.title,
+                body: L10n.Identification.ConfirmEnd.message,
+                confirm: L10n.Identification.ConfirmEnd.confirm,
+                deny: L10n.General.cancel
+            )
         }
         
-        store.send(.routeAction(1, action: .canInput(.done(can: can, pushesToPINEntry: true)))) {
-            $0.can = can
+        store.receive(.shared(.push(.canInput(CANInput.State(pushesToPINEntry: true))))) {
+            $0.routes.append(.push(.shared(.canInput(CANInput.State(pushesToPINEntry: true)))))
+        }
+        
+        store.send(.routeAction(1, action: .shared(.canInput(.done(can: can, pushesToPINEntry: true))))) {
+            $0.shared.can = can
             $0.routes.append(.push(
                 .canTransportPINInput(SetupTransportPIN.State(enteredPIN: "", digits: 5, attempts: 1))
             ))
@@ -102,7 +124,9 @@ class SetupCANCoordinatorTests: XCTestCase {
                                                     oldTransportPIN: transportPIN,
                                                     canAndChangedPINCallback: canAndChangedPINCallback,
                                                     tokenURL: demoTokenURL,
-                                                    attempt: 0,
+                                                    _shared: SharedCANCoordinator.State(
+                                                        attempt: 0
+                                                    ),
                                                     states: [
                                                         .root(.canScan(SetupCANScan.State(transportPIN: transportPIN,
                                                                                           newPIN: newPIN,

--- a/BundesIdentTests/Views/Identification/IdentificationCANScanTests.swift
+++ b/BundesIdentTests/Views/Identification/IdentificationCANScanTests.swift
@@ -22,7 +22,6 @@ final class IdentificationCANScanTests: XCTestCase {
     }
     
     func testOnAppearDoesTriggerScanningWhenNotAlreadyScanning() throws {
-        let request = EIDAuthenticationRequest.preview
         let pin = "123456"
         let can = "123456"
         let pinCANCallback = PINCANCallback(id: UUID(number: 0)) { pin, can in }
@@ -41,7 +40,6 @@ final class IdentificationCANScanTests: XCTestCase {
     }
     
     func testOnAppearIgnoredWhenAlreadyScanning() throws {
-        let request = EIDAuthenticationRequest.preview
         let pin = "123456"
         let can = "123456"
         let pinCANCallback = PINCANCallback(id: UUID(number: 0)) { pin, can in }
@@ -55,7 +53,6 @@ final class IdentificationCANScanTests: XCTestCase {
     }
     
     func testCancellation() throws {
-        let request = EIDAuthenticationRequest.preview
         let pin = "123456"
         let can = "123456"
         let pinCANCallback = PINCANCallback(id: UUID(number: 0)) { pin, can in }
@@ -73,7 +70,6 @@ final class IdentificationCANScanTests: XCTestCase {
     }
     
     func testWrongCAN() throws {
-        let request = EIDAuthenticationRequest.preview
         let pin = "123456"
         let can = "123456"
         let pinCANCallback = PINCANCallback(id: UUID(number: 0)) { pin, can in }
@@ -91,7 +87,6 @@ final class IdentificationCANScanTests: XCTestCase {
     }
     
     func testShowNFCInfo() {
-        let request = EIDAuthenticationRequest.preview
         let pin = "123456"
         let can = "123456"
         let pinCANCallback = PINCANCallback(id: UUID(number: 0)) { pin, can in }
@@ -114,7 +109,6 @@ final class IdentificationCANScanTests: XCTestCase {
     }
     
     func testStartScanTracking() {
-        let request = EIDAuthenticationRequest.preview
         let pin = "123456"
         let can = "123456"
         let pinCANCallback = PINCANCallback(id: UUID(number: 0)) { pin, can in }

--- a/BundesIdentUITests/IdentificationCANUITests.swift
+++ b/BundesIdentUITests/IdentificationCANUITests.swift
@@ -23,7 +23,7 @@ final class IdentificationCANUITests: XCTestCase {
         
         app.buttons[L10n.Identification.PersonalPIN.continue].wait().tap()
         app.navigationBars.buttons["Debug"].wait().tap()
-        app.buttons["runCardSuspended"].wait().tap()
+        app.buttons["askForCAN"].wait().tap()
         
         app.buttons[L10n.Identification.Can.Intro.continue].wait().tap()
         
@@ -83,7 +83,7 @@ final class IdentificationCANUITests: XCTestCase {
         app.toolbars["Toolbar"].buttons[L10n.Identification.PersonalPIN.continue].wait().tap()
         app.activityIndicators["ScanProgressView"].assertExistence()
         app.navigationBars.buttons["Debug"].wait().tap()
-        app.buttons["runCardSuspended"].wait().tap()
+        app.buttons["askForCAN"].wait().tap()
         
         app.navigationBars.buttons[L10n.General.cancel].wait().tap()
         app.buttons[L10n.Identification.ConfirmEnd.confirm].wait().tap()
@@ -111,7 +111,7 @@ final class IdentificationCANUITests: XCTestCase {
         
         app.toolbars["Toolbar"].buttons[L10n.Identification.PersonalPIN.continue].wait().tap()
         app.navigationBars.buttons["Debug"].wait().tap()
-        app.buttons["runCardSuspended"].wait().tap()
+        app.buttons["askForCAN"].wait().tap()
         
         app.buttons[L10n.Identification.Can.Intro.continue].wait().tap()
         
@@ -146,7 +146,7 @@ final class IdentificationCANUITests: XCTestCase {
         
         app.toolbars["Toolbar"].buttons[L10n.Identification.PersonalPIN.continue].wait().tap()
         app.navigationBars.buttons["Debug"].wait().tap()
-        app.buttons["runCardSuspended"].wait().tap()
+        app.buttons["askForCAN"].wait().tap()
         
         app.buttons[L10n.Identification.Can.Intro.continue].wait().tap()
         
@@ -157,7 +157,7 @@ final class IdentificationCANUITests: XCTestCase {
         app.activityIndicators["ScanProgressView"].assertExistence()
         
         app.navigationBars.buttons["Debug"].wait().tap()
-        app.buttons["cancelCANScan"].wait().tap()
+        app.buttons["cancel"].wait().tap()
         
         app.buttons[L10n.Identification.Scan.scan].assertExistence()
     }

--- a/BundesIdentUITests/IdentificationUITests.swift
+++ b/BundesIdentUITests/IdentificationUITests.swift
@@ -165,7 +165,7 @@ final class IdentificationUITests: XCTestCase {
         
         app.toolbars["Toolbar"].buttons[L10n.Identification.PersonalPIN.continue].wait().tap()
         app.navigationBars.buttons["Debug"].wait().tap()
-        app.buttons["cancelPINScan"].wait().tap()
+        app.buttons["cancel"].wait().tap()
         app.buttons[L10n.Identification.Scan.scan].assertExistence()
     }
     

--- a/BundesIdentUITests/SetupCANUITests.swift
+++ b/BundesIdentUITests/SetupCANUITests.swift
@@ -32,7 +32,7 @@ final class SetupCANUITests: XCTestCase {
         app.buttons[L10n.FirstTimeUser.Scan.scan].wait().tap()
         
         app.navigationBars.buttons["Debug"].wait().tap()
-        app.buttons["runCardSuspended"].wait().tap()
+        app.buttons["askForCAN"].wait().tap()
         
         app.buttons[L10n.Identification.Can.Intro.continue].wait().tap()
         
@@ -42,7 +42,7 @@ final class SetupCANUITests: XCTestCase {
         app.buttons[L10n.Identification.Can.Input.continue].wait().tap()
         app.activityIndicators["ScanProgressView"].assertExistence()
         app.navigationBars.buttons["Debug"].wait().tap()
-        app.buttons["runCANError"].wait().tap()
+        app.buttons["askForCAN"].wait().tap()
         
         let incorrectCANTextField = app.textFields[L10n.Identification.Can.IncorrectInput.canInputLabel]
         incorrectCANTextField.wait().tap()
@@ -155,7 +155,7 @@ final class SetupCANUITests: XCTestCase {
         app.buttons[L10n.FirstTimeUser.Scan.scan].wait().tap()
         
         app.navigationBars.buttons["Debug"].wait().tap()
-        app.buttons["runCardSuspended"].wait().tap()
+        app.buttons["askForCAN"].wait().tap()
         
         app.buttons[L10n.Identification.Can.Intro.continue].wait().tap()
         


### PR DESCRIPTION
Goal of the refactoring: Extract the common state, actions and logic of both CAN flows.

Part of this PR: Extract the shared logic, state and actions from the setup and introduce a SharedCAN-Reducer.

Next: Use the SharedCAN-Reducer in the identification flow.