### PR TITLE
Fix styling of links in markdown

### DIFF
--- a/BundesIdent.xcodeproj/project.pbxproj
+++ b/BundesIdent.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4334B4D329A64F00001FF36C /* Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4334B4D229A64F00001FF36C /* Markdown.swift */; };
 		43EE410329A3D89700A96953 /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43EE410229A3D89700A96953 /* BackButton.swift */; };
 		B91E34512938C0B9005BE658 /* IdentificationOverviewLoadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91E34502938C0B9005BE658 /* IdentificationOverviewLoadingTests.swift */; };
 		B922901E294203360018D671 /* IdentificationCANCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B922901D294203360018D671 /* IdentificationCANCoordinatorTests.swift */; };
@@ -198,6 +199,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4334B4D229A64F00001FF36C /* Markdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Markdown.swift; sourceTree = "<group>"; };
 		43EE410229A3D89700A96953 /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		B91E34502938C0B9005BE658 /* IdentificationOverviewLoadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentificationOverviewLoadingTests.swift; sourceTree = "<group>"; };
 		B922901D294203360018D671 /* IdentificationCANCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentificationCANCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -678,6 +680,7 @@
 				E1CD8E8E2820395F008ADA2A /* BundButtonStyle.swift */,
 				E1CD8E87281FF62F008ADA2A /* Colors.swift */,
 				E1AB879D282283AB00C7FC94 /* Fonts.swift */,
+				4334B4D229A64F00001FF36C /* Markdown.swift */,
 			);
 			path = Theme;
 			sourceTree = "<group>";
@@ -1124,6 +1127,7 @@
 				E1AB879E282283AB00C7FC94 /* Fonts.swift in Sources */,
 				E16708BC283D824D001A1637 /* Scheduler+Animation.swift in Sources */,
 				E1C2D8BA28620E2B000E0F5B /* IdentificationPINScan.swift in Sources */,
+				4334B4D329A64F00001FF36C /* Markdown.swift in Sources */,
 				E593E26E2816853A00154EB0 /* StopServiceHandler.swift in Sources */,
 				E16708B3283D4ED2001A1637 /* SetupCoordinator.swift in Sources */,
 				E1658735299508D100FCF9C8 /* CancelId.swift in Sources */,

--- a/BundesIdent.xcodeproj/project.pbxproj
+++ b/BundesIdent.xcodeproj/project.pbxproj
@@ -1949,7 +1949,7 @@
 			repositoryURL = "https://github.com/gonzalezreal/MarkdownUI";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 2.0.0;
 			};
 		};
 		E15C22FE2850F5A8005CCBB9 /* XCRemoteSwiftPackageReference "open-ecard-ios" */ = {

--- a/BundesIdent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BundesIdent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "attributedtext",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/AttributedText",
-      "state" : {
-        "revision" : "0e811cb14de367bbd58a94d12259687e5ee08bea",
-        "version" : "1.0.1"
-      }
-    },
-    {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
@@ -50,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/MarkdownUI",
       "state" : {
-        "revision" : "6a33c60ad430772d69ac5278e35474d6b3e5d30a",
-        "version" : "1.1.1"
+        "revision" : "5e15c0d75e42b9840301503e0df681027d4bea05",
+        "version" : "2.0.1"
       }
     },
     {
@@ -61,15 +52,6 @@
       "state" : {
         "branch" : "develop",
         "revision" : "1d853c3b7acfdb6552f63666390e37374f87c5cd"
-      }
-    },
-    {
-      "identity" : "networkimage",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/NetworkImage",
-      "state" : {
-        "revision" : "c97f83e771c95186af80ef6118f158852a9e54be",
-        "version" : "4.0.1"
       }
     },
     {
@@ -151,15 +133,6 @@
       "state" : {
         "revision" : "fd34c544ad27f3ba6b19142b348005bfa85b6005",
         "version" : "0.6.0"
-      }
-    },
-    {
-      "identity" : "swiftcommonmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/SwiftCommonMark",
-      "state" : {
-        "revision" : "ed252beaddecce28ea6363f800c773d6169011b8",
-        "version" : "1.0.0"
       }
     },
     {

--- a/BundesIdent/Theme/Fonts.swift
+++ b/BundesIdent/Theme/Fonts.swift
@@ -37,10 +37,12 @@ extension UIFont {
     }
 }
 
-extension MarkdownStyle.Font {
+extension MarkdownUI.FontProperties {
     
-    /// 18pt – regular
-    static let bundBody = MarkdownStyle.Font.custom(bundFontName, size: 18)
+    /// body-l
+    /// 18/24
+    /// regular
+    static let bodyLRegular: Self = .init(family: .custom(bundFontName), size: 18)
 }
 
 public extension View {
@@ -90,7 +92,7 @@ public extension View {
             .foregroundColor(color)
     }
     
-    /// body-l
+    /// body-m
     /// 16/20
     /// bold
     func bodyMBold(color: Color? = .blackish) -> some View {
@@ -98,7 +100,7 @@ public extension View {
             .foregroundColor(color)
     }
     
-    /// body-l
+    /// body-m
     /// 16/20
     /// regular
     func bodyMRegular(color: Color? = .blackish) -> some View {

--- a/BundesIdent/Theme/Markdown.swift
+++ b/BundesIdent/Theme/Markdown.swift
@@ -1,0 +1,15 @@
+import MarkdownUI
+
+extension Theme {
+
+    static let bund = Theme
+        .basic
+        .text {
+            FontProperties.bodyLRegular
+            ForegroundColor(.blackish)
+        }
+        .link {
+            FontWeight(.bold)
+            ForegroundColor(.accentColor)
+        }
+}

--- a/BundesIdent/Views/Identification/IdentificationCANOrderNewPIN.swift
+++ b/BundesIdent/Views/Identification/IdentificationCANOrderNewPIN.swift
@@ -21,11 +21,9 @@ struct IdentificationCANOrderNewPINView: View {
                     Text(L10n.Identification.Can.OrderNewPin.title)
                         .headingXL()
                     Markdown(L10n.Identification.Can.OrderNewPin.body)
-                        .markdownStyle(MarkdownStyle(font: .bundBody))
-                        .foregroundColor(.blackish)
+                        .markdownTheme(.bund)
                         .fixedSize(horizontal: false, vertical: true)
-                        .accentColor(.blue800)
-                            
+
                     if let imageMeta = ImageMeta(asset: Asset.missingPINBrief) {
                         imageMeta.image
                             .resizable()

--- a/BundesIdent/Views/SupplementaryViews/AboutView.swift
+++ b/BundesIdent/Views/SupplementaryViews/AboutView.swift
@@ -9,7 +9,7 @@ struct AboutView: View {
         ScrollView {
             HStack {
                 Markdown(markdown)
-                    .markdownStyle(MarkdownStyle(font: .bundBody))
+                    .markdownTheme(.bund)
                     .padding(24)
                 Spacer()
             }

--- a/BundesIdent/Views/SupplementaryViews/HeaderView.swift
+++ b/BundesIdent/Views/SupplementaryViews/HeaderView.swift
@@ -42,8 +42,7 @@ struct HeaderView: View {
             }
             if let message {
                 Markdown(message)
-                    .markdownStyle(MarkdownStyle(font: .bundBody))
-                    .foregroundColor(.blackish)
+                    .markdownTheme(.bund)
                     .fixedSize(horizontal: false, vertical: true)
             }
             if let imageMeta {


### PR DESCRIPTION
To support better markdown styling we need to update `MarkdownUI` to version 2.0.0.

| Before | After | Design |
| - | - | - |
| <img width="489" alt="Screenshot 2023-02-22 at 15 03 10" src="https://user-images.githubusercontent.com/5408486/220645960-0a8ee932-d192-42fe-be5b-cebe5f8d07b2.png"> | <img width="489" alt="Screenshot 2023-02-22 at 15 08 40" src="https://user-images.githubusercontent.com/5408486/220646049-89c12bdc-7a0d-4e88-8e20-07bedc00044d.png"> | <img width="343" alt="Screenshot 2023-02-22 at 15 09 56" src="https://user-images.githubusercontent.com/5408486/220646091-130df152-9182-41fc-9607-4b5838a71781.png"> |
