### PR TITLE
Add missing bottom spacing for content in dialogs and adjust spacings for markdown views

### DIFF
--- a/BundesIdent/Theme/Markdown.swift
+++ b/BundesIdent/Theme/Markdown.swift
@@ -12,4 +12,10 @@ extension Theme {
             FontWeight(.bold)
             ForegroundColor(.accentColor)
         }
+        .listItem {
+            $0.markdownMargin(top: .em(0.7))
+        }
+        .paragraph {
+            $0.markdownMargin(top: .zero, bottom: .em(1.4))
+        }
 }

--- a/BundesIdent/Theme/Markdown.swift
+++ b/BundesIdent/Theme/Markdown.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import MarkdownUI
 
 extension Theme {
@@ -11,6 +12,10 @@ extension Theme {
         .link {
             FontWeight(.bold)
             ForegroundColor(.accentColor)
+        }
+        .bulletedListMarker { _ in
+            Text("• ")
+                .relativeFrame(minWidth: .em(1.0), alignment: .trailing)
         }
         .listItem {
             $0.markdownMargin(top: .em(0.7))

--- a/BundesIdent/Views/SupplementaryViews/AboutView.swift
+++ b/BundesIdent/Views/SupplementaryViews/AboutView.swift
@@ -28,3 +28,13 @@ struct AboutView: View {
         }
     }
 }
+
+struct AboutView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        NavigationView {
+            AboutView(title: L10n.Privacy.title,
+                      markdown: L10n.Privacy.text)
+        }
+    }
+}

--- a/BundesIdent/Views/SupplementaryViews/DialogView.swift
+++ b/BundesIdent/Views/SupplementaryViews/DialogView.swift
@@ -18,6 +18,7 @@ struct DialogView<Action>: View {
                            message: message,
                            imageMeta: imageMeta)
                     .padding(.horizontal)
+                    .padding(.bottom, 24)
             }
             DialogButtons(store: store,
                           secondary: secondaryButton,


### PR DESCRIPTION
Aside of adding bottom padding for the content of `DialogView` this PR fixes the style of the bullet lists to make the points more readable (styling from the Figma files, also applies to informational views accessible from `Home`).

| Before | After |
| - | - |
| <img width="200" alt="Screenshot 2023-02-23 at 13 09 12" src="https://user-images.githubusercontent.com/5408486/220902875-e9efface-f686-4894-a1ce-d3c47a761f78.png"> | <img width="200" alt="Screenshot 2023-02-23 at 13 10 01" src="https://user-images.githubusercontent.com/5408486/220902919-bf1d5eaf-081d-49b7-83d0-05856a192c9b.png"> |
