### PR TITLE
Workaround macOS bug when specifying base64 output

### DIFF
--- a/.github/workflows/Prototype.yml
+++ b/.github/workflows/Prototype.yml
@@ -129,8 +129,8 @@ jobs:
           APPSTORECONNECT_API_KEY_PATH=$RUNNER_TEMP/api_key.json
 
           # import certificate and provisioning profile from secrets
-          echo -n "$DISTRIBUTION_CERTIFICATE_P12_BASE64" | base64 --decode --output $CERTIFICATE_PATH
-          echo -n "$PROTOTYPE_DISTRIBUTION_PROVISIONING_PROFILE_BASE64" | base64 --decode --output $PP_PATH
+          echo -n "$DISTRIBUTION_CERTIFICATE_P12_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$PROTOTYPE_DISTRIBUTION_PROVISIONING_PROFILE_BASE64" | base64 --decode -o $PP_PATH
 
           # create temporary keychain
           security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -206,8 +206,8 @@ jobs:
           APPSTORECONNECT_API_KEY_PATH=$RUNNER_TEMP/api_key.json
 
           # import certificate and provisioning profile from secrets
-          echo -n "$DISTRIBUTION_CERTIFICATE_P12_BASE64" | base64 --decode --output $CERTIFICATE_PATH
-          echo -n "$DISTRIBUTION_PROVISIONING_PROFILE_BASE64" | base64 --decode --output $PP_PATH
+          echo -n "$DISTRIBUTION_CERTIFICATE_P12_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$DISTRIBUTION_PROVISIONING_PROFILE_BASE64" | base64 --decode -o $PP_PATH
 
           # create temporary keychain
           security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
@@ -289,8 +289,8 @@ jobs:
           APPSTORECONNECT_API_KEY_PATH=$RUNNER_TEMP/api_key.json
 
           # import certificate and provisioning profile from secrets
-          echo -n "$DISTRIBUTION_CERTIFICATE_P12_BASE64" | base64 --decode --output $CERTIFICATE_PATH
-          echo -n "$PREVIEW_DISTRIBUTION_PROVISIONING_PROFILE_BASE64" | base64 --decode --output $PP_PATH
+          echo -n "$DISTRIBUTION_CERTIFICATE_P12_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$PREVIEW_DISTRIBUTION_PROVISIONING_PROFILE_BASE64" | base64 --decode -o $PP_PATH
 
           # create temporary keychain
           security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH


### PR DESCRIPTION
This is due to updating our CI to the latest macOS version which changed how the base64 tool interprets the `--output` parameter. As a workaround, we use the `-o` parameter.

See the following action that failed because of the update:
https://github.com/digitalservicebund/useid-app-ios/actions/runs/4447668556/jobs/7809504103