### PR TITLE
Fix issues with A/B testing

### DIFF
--- a/BundesIdent/Managers/ABTester.swift
+++ b/BundesIdent/Managers/ABTester.swift
@@ -89,7 +89,7 @@ final class UnleashManager: ABTester {
         let matomoTestName = test.name.replacingOccurrences(of: ".", with: "_")
         analytics.track(event: .init(category: "abtesting", action: matomoTestName, name: variantName))
         issueTracker.addInfoBreadcrumb(category: "abtest", message: "\(test.name): \(variantName)")
-        return variantName == "variation"
+        return variantName == "Variation"
     }
 }
 

--- a/BundesIdent/Managers/ABTester.swift
+++ b/BundesIdent/Managers/ABTester.swift
@@ -11,7 +11,7 @@ enum ABTest: CaseIterable {
     var name: String {
         switch self {
 #if PREVIEW
-        case .test: return "test"
+        case .test: return "bundesIdent.test"
 #endif
         case .setupIntroductionExplanation: return "bundesIdent.setup_introduction_explanation"
         }
@@ -86,7 +86,8 @@ final class UnleashManager: ABTester {
         guard state == .active, let test, let variantName = unleashClient.variantName(forTestName: test.name)
         else { return false }
 
-        analytics.track(event: .init(category: "abtesting", action: test.name, name: variantName))
+        let matomoTestName = test.name.replacingOccurrences(of: ".", with: "_")
+        analytics.track(event: .init(category: "abtesting", action: matomoTestName, name: variantName))
         issueTracker.addInfoBreadcrumb(category: "abtest", message: "\(test.name): \(variantName)")
         return variantName == "variation"
     }

--- a/BundesIdent/Managers/ABTester.swift
+++ b/BundesIdent/Managers/ABTester.swift
@@ -21,21 +21,25 @@ enum ABTest: CaseIterable {
 final class UnleashManager: ABTester {
 
     convenience init(url: String, clientKey: String, analytics: AnalyticsClient, issueTracker: IssueTracker) {
-        let unleashClient = UnleashClient(unleashUrl: url, clientKey: clientKey, refreshInterval: .max, appName: "bundesIdent.iOS")
+        let unleashClient = UnleashClient(unleashUrl: url, clientKey: clientKey, refreshInterval: .max)
         self.init(unleashClient: unleashClient, analytics: analytics, issueTracker: issueTracker)
     }
 
-    init(unleashClient: UnleashClientWrapper, analytics: AnalyticsClient, issueTracker: IssueTracker) {
+    init(unleashClient: UnleashClientWrapper, analytics: AnalyticsClient, issueTracker: IssueTracker, uuid: () -> UUID = UUID.init) {
         self.unleashClient = unleashClient
         self.analytics = analytics
         self.issueTracker = issueTracker
 
-        unleashClient.context["supportedToggles"] = ABTest.allCases
+        var context = unleashClient.context
+        context["appName"] = "bundesIdent.iOS"
+        context["sessionId"] = uuid().uuidString
+        context["supportedToggles"] = ABTest.allCases
 #if PREVIEW
             .filter { $0 != .test }
 #endif
             .map(\.name)
             .joined(separator: ",")
+        unleashClient.context = context
     }
 
     private let unleashClient: UnleashClientWrapper

--- a/BundesIdentTests/Managers/UnleashManagerTests.swift
+++ b/BundesIdentTests/Managers/UnleashManagerTests.swift
@@ -38,11 +38,15 @@ final class UnleashManagerTests: XCTestCase {
             }
         }
 
-        let sut = UnleashManager(unleashClient: mockUnleashClient, analytics: mockAnalyticsClient, issueTracker: mockIssueTracker)
+        let uuid = { UUID(uuidString: "00000000-0000-0000-0000-000000000000")! }
+        let sut = UnleashManager(unleashClient: mockUnleashClient, analytics: mockAnalyticsClient, issueTracker: mockIssueTracker, uuid: uuid)
 
         verify(mockUnleashClient).context.set(any())
-        XCTAssert(context["supportedToggles"]?.contains(ABTest.test.name) == false)
+        XCTAssertEqual(context.count, 4)
         XCTAssertEqual(context["someKey"], "someValue")
+        XCTAssert(context["supportedToggles"]?.contains(ABTest.test.name) == false)
+        XCTAssertEqual(context["appName"], "bundesIdent.iOS")
+        XCTAssertEqual(context["sessionId"], "00000000-0000-0000-0000-000000000000")
         XCTAssertNil(context["someOtherKey"])
         XCTAssertEqual(sut.state, .initial)
     }

--- a/BundesIdentTests/Managers/UnleashManagerTests.swift
+++ b/BundesIdentTests/Managers/UnleashManagerTests.swift
@@ -113,13 +113,13 @@ final class UnleashManagerTests: XCTestCase {
     func testIsVariationActivatedWhenClientReturnsVariationTracksVariationAndReturnsTrue() async {
         let sut = UnleashManager(unleashClient: mockUnleashClient, analytics: mockAnalyticsClient, issueTracker: mockIssueTracker)
         stub(mockUnleashClient) {
-            $0.variantName(forTestName: "test").thenReturn("variation")
+            $0.variantName(forTestName: "bundesIdent.test").thenReturn("variation")
         }
         await sut.prepare()
 
         let result = sut.isVariationActivated(for: .test)
 
-        verify(mockAnalyticsClient).track(event: AnalyticsEvent(category: "abtesting", action: "test", name: "variation"))
+        verify(mockAnalyticsClient).track(event: AnalyticsEvent(category: "abtesting", action: "bundesIdent_test", name: "variation"))
         verify(mockIssueTracker).addBreadcrumb(crumb: any())
         XCTAssertTrue(result)
     }
@@ -127,13 +127,13 @@ final class UnleashManagerTests: XCTestCase {
     func testIsVariationActivatedWhenClientReturnsOriginalTracksOriginalAndReturnsFalse() async {
         let sut = UnleashManager(unleashClient: mockUnleashClient, analytics: mockAnalyticsClient, issueTracker: mockIssueTracker)
         stub(mockUnleashClient) {
-            $0.variantName(forTestName: "test").thenReturn("original")
+            $0.variantName(forTestName: "bundesIdent.test").thenReturn("original")
         }
         await sut.prepare()
 
         let result = sut.isVariationActivated(for: .test)
 
-        verify(mockAnalyticsClient).track(event: AnalyticsEvent(category: "abtesting", action: "test", name: "original"))
+        verify(mockAnalyticsClient).track(event: AnalyticsEvent(category: "abtesting", action: "bundesIdent_test", name: "original"))
         verify(mockIssueTracker).addBreadcrumb(crumb: any())
         XCTAssertFalse(result)
     }

--- a/BundesIdentTests/Managers/UnleashManagerTests.swift
+++ b/BundesIdentTests/Managers/UnleashManagerTests.swift
@@ -113,13 +113,13 @@ final class UnleashManagerTests: XCTestCase {
     func testIsVariationActivatedWhenClientReturnsVariationTracksVariationAndReturnsTrue() async {
         let sut = UnleashManager(unleashClient: mockUnleashClient, analytics: mockAnalyticsClient, issueTracker: mockIssueTracker)
         stub(mockUnleashClient) {
-            $0.variantName(forTestName: "bundesIdent.test").thenReturn("variation")
+            $0.variantName(forTestName: "bundesIdent.test").thenReturn("Variation")
         }
         await sut.prepare()
 
         let result = sut.isVariationActivated(for: .test)
 
-        verify(mockAnalyticsClient).track(event: AnalyticsEvent(category: "abtesting", action: "bundesIdent_test", name: "variation"))
+        verify(mockAnalyticsClient).track(event: AnalyticsEvent(category: "abtesting", action: "bundesIdent_test", name: "Variation"))
         verify(mockIssueTracker).addBreadcrumb(crumb: any())
         XCTAssertTrue(result)
     }
@@ -127,13 +127,13 @@ final class UnleashManagerTests: XCTestCase {
     func testIsVariationActivatedWhenClientReturnsOriginalTracksOriginalAndReturnsFalse() async {
         let sut = UnleashManager(unleashClient: mockUnleashClient, analytics: mockAnalyticsClient, issueTracker: mockIssueTracker)
         stub(mockUnleashClient) {
-            $0.variantName(forTestName: "bundesIdent.test").thenReturn("original")
+            $0.variantName(forTestName: "bundesIdent.test").thenReturn("Original")
         }
         await sut.prepare()
 
         let result = sut.isVariationActivated(for: .test)
 
-        verify(mockAnalyticsClient).track(event: AnalyticsEvent(category: "abtesting", action: "bundesIdent_test", name: "original"))
+        verify(mockAnalyticsClient).track(event: AnalyticsEvent(category: "abtesting", action: "bundesIdent_test", name: "Original"))
         verify(mockIssueTracker).addBreadcrumb(crumb: any())
         XCTAssertFalse(result)
     }


### PR DESCRIPTION
We have assorted issues with the current setup of A/B testing tools which this PR addresses.

1. Matomo doesn’t allow special characters in the test name. Our naming scheme in Unleash is `project.name_of_the_feature`. We now replace `.` with `_` for before sending the string to Matomo. This means we need to create test with `project_name_of_the_feature` on their side. Weirdly underscore still falls under "alphanumeric characters" from Matomo’s perspective.
2. Matomo’s documentation states that in order to a variant as control we supposed to send `"original"` as event’s `name`. When testing with Preview website I however discovered that it doesn’t actually puts this users into correct user group. In the interface the group is called `Original`, so I tried capitalizing it on our side (specifically in Unleash) too. Then it works. This value is not hardcoded in the app, but to make the other group consistent with this naming scheme I'm renaming it to `Variation` and so there is a change in code.
3. When we are not providing a random session id for Unleash it seems like some kind of caching is kicking in and serves the same variant over and over again. Looking at their source code `.reloadIgnoringLocalCacheData` is set for the requests which leaves the room for remote caching. To avoid it (in consistency with Android implementation, thanks @elaydis!) we are now setting the session id (which basically modifies the query parameters for Unleash requests making each request unique).