### PR TITLE
Clean up caching actions

### DIFF
--- a/.github/workflows/Prototype.yml
+++ b/.github/workflows/Prototype.yml
@@ -44,16 +44,6 @@ jobs:
       - name: Brew bundle
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: ./native_arch.sh brew bundle --no-lock
-      - name: Save dependencies
-        uses: actions/cache@v3
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
-        env:
-          cache-name: cache-dependencies
-        with:
-          path: |
-            vendor
-            .bundle
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock', 'Brewfile') }}
 
   bumpVersion:
     runs-on: [self-hosted, ARM64]
@@ -68,7 +58,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3        
       - name: Restore dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         id: cache-dependencies
         env:
           cache-name: cache-dependencies
@@ -77,6 +67,7 @@ jobs:
             vendor
             .bundle
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock', 'Brewfile') }}
+          fail-on-cache-miss: true
       - name: fastlane bump version and create tag
         env:
           VERSION: ${{ inputs.version }}
@@ -105,7 +96,7 @@ jobs:
         with:
           ref: ${{ needs.bumpVersion.outputs.gitTag }}     
       - name: Restore dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         id: cache-dependencies
         env:
           cache-name: cache-dependencies
@@ -114,6 +105,7 @@ jobs:
             vendor
             .bundle
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock', 'Brewfile') }}  
+          fail-on-cache-miss: true
       - name: Install the Apple certificate and provisioning profile
         env:
           DISTRIBUTION_CERTIFICATE_P12_BASE64: ${{ secrets.DISTRIBUTION_CERTIFICATE_P12_BASE64 }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -42,16 +42,6 @@ jobs:
       - name: Install brew dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: ./native_arch.sh brew bundle --no-lock
-      - name: Save dependencies
-        uses: actions/cache@v3
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
-        env:
-          cache-name: cache-dependencies
-        with:
-          path: |
-            vendor
-            .bundle
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock', 'Brewfile') }}
 
   buildForTesting:
     runs-on: [self-hosted, ARM64]
@@ -64,7 +54,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3          
       - name: Restore dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         env:
           cache-name: cache-dependencies
         with:
@@ -79,7 +69,7 @@ jobs:
             export LANGUAGE=en_US:en;
             bundle exec fastlane build_for_testing
       - name: Save DerivedData and SwiftPM folder
-        uses: actions/cache@v3
+        uses: actions/cache/save@v3
         env:
           cache-name: cache-derived-data
         with:
@@ -100,7 +90,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3       
       - name: Restore dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         env:
           cache-name: cache-dependencies
         with:
@@ -110,7 +100,7 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock', 'Brewfile') }}
           fail-on-cache-miss: true
       - name: Restore build data
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         env:
           cache-name: cache-derived-data
         with:
@@ -145,7 +135,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3        
       - name: Restore dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         id: cache-dependencies
         env:
           cache-name: cache-dependencies
@@ -154,6 +144,7 @@ jobs:
             vendor
             .bundle
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock', 'Brewfile') }}
+          fail-on-cache-miss: true
       - name: fastlane bump version and create tag
         env:
           VERSION: ${{ inputs.version }}
@@ -182,7 +173,7 @@ jobs:
         with:
           ref: ${{ needs.bumpVersion.outputs.gitTag }}
       - name: Restore dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         id: cache-dependencies
         env:
           cache-name: cache-dependencies
@@ -191,6 +182,7 @@ jobs:
             vendor
             .bundle
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock', 'Brewfile') }}  
+          fail-on-cache-miss: true
       - name: Install the Apple certificate and provisioning profile
         env:
           DISTRIBUTION_CERTIFICATE_P12_BASE64: ${{ secrets.DISTRIBUTION_CERTIFICATE_P12_BASE64 }}
@@ -265,7 +257,7 @@ jobs:
         with:
           ref: ${{ needs.bumpVersion.outputs.gitTag }}     
       - name: Restore dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         id: cache-dependencies
         env:
           cache-name: cache-dependencies
@@ -274,6 +266,7 @@ jobs:
             vendor
             .bundle
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock', 'Brewfile') }}  
+          fail-on-cache-miss: true
       - name: Install the Apple certificate and provisioning profile
         env:
           DISTRIBUTION_CERTIFICATE_P12_BASE64: ${{ secrets.DISTRIBUTION_CERTIFICATE_P12_BASE64 }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -18,7 +18,7 @@ jobs:
           eval "$(/opt/homebrew/bin/brew shellenv)"
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Restore dependencies
+      - name: Use cached dependencies
         uses: actions/cache@v3
         id: cache-dependencies
         env:
@@ -34,16 +34,6 @@ jobs:
       - name: Install brew dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: ./native_arch.sh brew bundle --no-lock
-      - name: Save dependencies
-        uses: actions/cache@v3
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
-        env:
-          cache-name: cache-dependencies
-        with:
-          path: |
-            vendor
-            .bundle
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock', 'Brewfile') }}
           
   lint:
     runs-on: [self-hosted, ARM64]
@@ -56,7 +46,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3       
       - name: Restore dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         env:
           cache-name: cache-dependencies
         with:
@@ -88,7 +78,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3          
       - name: Restore dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         env:
           cache-name: cache-dependencies
         with:
@@ -103,7 +93,7 @@ jobs:
             export LANGUAGE=en_US:en;
             bundle exec fastlane build_for_testing
       - name: Save DerivedData and SwiftPM folder
-        uses: actions/cache@v3
+        uses: actions/cache/save@v3
         env:
           cache-name: cache-derived-data
         with:
@@ -124,7 +114,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3       
       - name: Restore dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         env:
           cache-name: cache-dependencies
         with:
@@ -134,7 +124,7 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock', 'Brewfile') }}
           fail-on-cache-miss: true
       - name: Restore build data
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         env:
           cache-name: cache-derived-data
         with:
@@ -170,7 +160,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Restore dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         env:
           cache-name: cache-dependencies
         with:
@@ -180,7 +170,7 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock', 'Brewfile') }}
           fail-on-cache-miss: true
       - name: Restore build data
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         env:
           cache-name: cache-derived-data
         with:


### PR DESCRIPTION
When using `action/cache`, a post step is added automatically that saves the cache if it couldn't be restored. So we can get rid of the second `action/cache` in the dependencies step.

Explicitly stating `action/cache/[restore|save]` allows for better control what the action will do.