### PR TITLE
Fix tracking of Unleash errors

### DIFF
--- a/BundesIdent/Managers/ABTester.swift
+++ b/BundesIdent/Managers/ABTester.swift
@@ -93,7 +93,7 @@ final class UnleashManager: ABTester {
     }
 }
 
-private enum UnleashError: CustomNSError {
+enum UnleashError: CustomNSError {
     case requestTookTooLong(TimeInterval)
     case requestFailed(NSError)
 }


### PR DESCRIPTION
Call:
```swift
issueTracker.capture(error: UnleashError.requestFailed(PollerError.network as NSError))
```

Outcome before:
```swift
po event.error
BundesIdent.(unknown context at $1017c52b4).UnleashError.requestFailed(UnleashProxyClientSwift.PollerError.network)
```
Outcome after:
```swift
po event.error
BundesIdent.UnleashError.requestFailed(UnleashProxyClientSwift.PollerError.network)
```
