### PR TITLE
Use scanAvailable to disable initiating scan when its still running

### DIFF
--- a/BundesIdent/TCA/Coordinator.swift
+++ b/BundesIdent/TCA/Coordinator.swift
@@ -178,7 +178,7 @@ struct Coordinator: ReducerProtocol {
             Screen()
         }
 #if DEBUG
-            ._printChanges(.log({ logger.debug("\($0)") }))
+        ._printChanges(.log({ logger.debug("\($0)") }))
 #endif
         Reduce(tracking)
     }

--- a/BundesIdent/Views/Identification/IdentificationOverview/IdentificationOverviewLoading.swift
+++ b/BundesIdent/Views/Identification/IdentificationOverview/IdentificationOverviewLoading.swift
@@ -93,7 +93,7 @@ struct IdentificationOverviewLoadingView: View {
             ViewStore(store.stateless).send(.onAppear)
         }
 #if PREVIEW
-            .identifyDebugMenu(store: store.scope(state: \.availableDebugActions), action: IdentificationOverviewLoading.Action.runDebugSequence)
+        .identifyDebugMenu(store: store.scope(state: \.availableDebugActions), action: IdentificationOverviewLoading.Action.runDebugSequence)
 #endif
     }
 }

--- a/BundesIdent/Views/SupplementaryViews/SharedScan.swift
+++ b/BundesIdent/Views/SupplementaryViews/SharedScan.swift
@@ -62,6 +62,7 @@ struct SharedScanView: View {
                     ScanBody(helpTapped: { viewStore.send(.showHelp) })
                 }
                 DialogButtons(store: store.stateless, primary: .init(title: L10n.Scan.button, action: .onButtonTap))
+                    .disabled(!viewStore.scanAvailable)
             }
             .onChange(of: viewStore.state.attempt, perform: { _ in
                 viewStore.send(.onAttemptChange, animation: .easeInOut)

--- a/BundesIdentTests/TCA/IdentificationCANCoordinatorTests.swift
+++ b/BundesIdentTests/TCA/IdentificationCANCoordinatorTests.swift
@@ -210,6 +210,7 @@ class IdentificationCANCoordinatorTests: XCTestCase {
         store.send(.routeAction(0, action: .canScan(.shared(.startScan(userInitiated: true))))) {
             guard case .canScan(var scanState) = $0.routes[0].screen else { return XCTFail("Unexpected state") }
             scanState.shouldRestartAfterCancellation = false
+            scanState.shared.scanAvailable = false
             $0.routes[0].screen = .canScan(scanState)
         }
         

--- a/BundesIdentTests/TCA/IdentificationCoordinatorTests.swift
+++ b/BundesIdentTests/TCA/IdentificationCoordinatorTests.swift
@@ -403,6 +403,7 @@ class IdentificationCoordinatorTests: XCTestCase {
         store.send(.routeAction(0, action: .scan(.shared(.startScan(userInitiated: true))))) {
             guard case .scan(var scanState) = $0.routes[0].screen else { return XCTFail("Unexpected state") }
             scanState.shouldRestartAfterCancellation = false
+            scanState.shared.scanAvailable = false
             $0.routes[0].screen = .scan(scanState)
         }
         

--- a/BundesIdentTests/Views/Identification/IdentificationCANScanTests.swift
+++ b/BundesIdentTests/Views/Identification/IdentificationCANScanTests.swift
@@ -45,7 +45,9 @@ final class IdentificationCANScanTests: XCTestCase {
         
         store.dependencies.analytics = mockAnalyticsClient
         store.send(.shared(.onAppear))
-        store.receive(.shared(.startScan(userInitiated: false)))
+        store.receive(.shared(.startScan(userInitiated: false))) {
+            $0.shared.scanAvailable = false
+        }
         
         verify(mockEIDInteractionManager).setCAN(can)
     }
@@ -79,7 +81,9 @@ final class IdentificationCANScanTests: XCTestCase {
         store.dependencies.analytics = mockAnalyticsClient
         store.dependencies.eIDInteractionManager = mockEIDInteractionManager
         
-        store.send(.shared(.startScan(userInitiated: true)))
+        store.send(.shared(.startScan(userInitiated: true))) {
+            $0.shared.scanAvailable = false
+        }
         
         verify(mockAnalyticsClient).track(event: AnalyticsEvent(category: "identification",
                                                                 action: "buttonPressed",

--- a/BundesIdentTests/Views/Identification/IdentificationPINScanTests.swift
+++ b/BundesIdentTests/Views/Identification/IdentificationPINScanTests.swift
@@ -73,6 +73,7 @@ final class IdentificationPINScanTests: XCTestCase {
         
         store.send(.shared(.startScan(userInitiated: true))) {
             $0.shouldContinueAfterInterruption = true
+            $0.shared.scanAvailable = false
         }
         
         verify(mockEIDInteractionManager).acceptAccessRights()

--- a/BundesIdentTests/Views/Setup/SetupCANScanTests.swift
+++ b/BundesIdentTests/Views/Setup/SetupCANScanTests.swift
@@ -56,7 +56,9 @@ class SetupCANScanTests: XCTestCase {
             mock.setCAN(anyString()).thenDoNothing()
         }
 
-        store.send(.shared(.startScan(userInitiated: true)))
+        store.send(.shared(.startScan(userInitiated: true))) {
+            $0.shared.scanAvailable = false
+        }
         
         verify(mockEIDInteractionManager).setCAN(can)
         verify(mockAnalyticsClient).track(event: AnalyticsEvent(category: "Setup",
@@ -82,9 +84,11 @@ class SetupCANScanTests: XCTestCase {
             mock.setNewPIN(anyString()).thenDoNothing()
         }
 
-        store.send(.shared(.startScan(userInitiated: true)))
+        store.send(.shared(.startScan(userInitiated: true))) {
+            $0.shared.scanAvailable = false
+        }
         
-        store.send(.scanEvent(.success(.identificationStarted)))
+        store.send(.scanEvent(.success(.pinChangeStarted)))
         store.send(.scanEvent(.success(.cardInsertionRequested)))
         
         store.send(.scanEvent(.success(.cardRecognized)))
@@ -130,12 +134,19 @@ class SetupCANScanTests: XCTestCase {
                                              can: can),
             reducer: SetupCANScan()
         )
+        
+        store.send(.scanEvent(.success(.pinChangeStarted))) {
+            $0.shared.scanAvailable = false
+        }
 
         store.send(.scanEvent(.success(.pinChangeCancelled))) {
             $0.shouldRestartAfterCancellation = true
+            $0.shared.scanAvailable = true
         }
 
-        store.send(.shared(.startScan(userInitiated: true)))
+        store.send(.shared(.startScan(userInitiated: true))) {
+            $0.shared.scanAvailable = false
+        }
 
         store.receive(.changePIN)
     }

--- a/BundesIdentTests/Views/Setup/SetupScanTests.swift
+++ b/BundesIdentTests/Views/Setup/SetupScanTests.swift
@@ -53,6 +53,7 @@ class SetupScanTests: XCTestCase {
 
         store.send(.shared(.startScan(userInitiated: false))) {
             $0.shouldRestartAfterCancellation = true
+            $0.shared.scanAvailable = false
         }
 
         store.receive(.changePIN)
@@ -71,6 +72,7 @@ class SetupScanTests: XCTestCase {
 
         store.send(.shared(.startScan(userInitiated: true))) {
             $0.shouldRestartAfterCancellation = true
+            $0.shared.scanAvailable = false
         }
 
         store.receive(.changePIN)
@@ -96,7 +98,9 @@ class SetupScanTests: XCTestCase {
             mock.setNewPIN(anyString()).thenDoNothing()
         }
 
-        store.send(.scanEvent(.success(.identificationStarted)))
+        store.send(.scanEvent(.success(.pinChangeStarted))) {
+            $0.shared.scanAvailable = false
+        }
         store.send(.scanEvent(.success(.cardInsertionRequested)))
 
         store.send(.scanEvent(.success(.cardRecognized)))


### PR DESCRIPTION
- Remove identification callbacks in setup
- Fix tests