### PR TITLE
Add underline for links (+ new link style for buttons)

### DIFF
--- a/BundesIdent.xcodeproj/project.pbxproj
+++ b/BundesIdent.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		4398414629F981BB00B91714 /* IdentificationInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4398414529F981BB00B91714 /* IdentificationInformation.swift */; };
 		4398414829F9822200B91714 /* ScanOverlayMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4398414729F9822200B91714 /* ScanOverlayMessages.swift */; };
 		43AE178929C3C1A700902E27 /* SetupIntroVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AE178829C3C1A700902E27 /* SetupIntroVariation.swift */; };
+		43BBC5332A177B57008212B7 /* LinkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BBC5322A177B57008212B7 /* LinkButton.swift */; };
 		43EE410329A3D89700A96953 /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43EE410229A3D89700A96953 /* BackButton.swift */; };
 		B91E34512938C0B9005BE658 /* IdentificationOverviewLoadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91E34502938C0B9005BE658 /* IdentificationOverviewLoadingTests.swift */; };
 		B922901E294203360018D671 /* IdentificationCANCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B922901D294203360018D671 /* IdentificationCANCoordinatorTests.swift */; };
@@ -206,6 +207,7 @@
 		4398414529F981BB00B91714 /* IdentificationInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentificationInformation.swift; sourceTree = "<group>"; };
 		4398414729F9822200B91714 /* ScanOverlayMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanOverlayMessages.swift; sourceTree = "<group>"; };
 		43AE178829C3C1A700902E27 /* SetupIntroVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupIntroVariation.swift; sourceTree = "<group>"; };
+		43BBC5322A177B57008212B7 /* LinkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkButton.swift; sourceTree = "<group>"; };
 		43EE410229A3D89700A96953 /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		B91E34502938C0B9005BE658 /* IdentificationOverviewLoadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentificationOverviewLoadingTests.swift; sourceTree = "<group>"; };
 		B922901D294203360018D671 /* IdentificationCANCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentificationCANCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -602,6 +604,7 @@
 				E144EBD728C63A4D009B4900 /* AboutView.swift */,
 				43EE410229A3D89700A96953 /* BackButton.swift */,
 				D201402628C5E6FD0002A054 /* Box.swift */,
+				43BBC5322A177B57008212B7 /* LinkButton.swift */,
 				E17604D0287E24F1007DFA10 /* DebugMenu.swift */,
 				E16708B9283D7CA1001A1637 /* DialogButtons.swift */,
 				E16708B6283D7C2B001A1637 /* DialogView.swift */,
@@ -936,8 +939,8 @@
 			mainGroup = E5CEB271281041330076B9FE;
 			packageReferences = (
 				E13925B928410F3F00161F5C /* XCRemoteSwiftPackageReference "Cuckoo" */,
-				E128E0B8288941DC00C5195F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */,
-				E1BC3D8428B7E919007A7B39 /* XCRemoteSwiftPackageReference "LicensePlistViewController.git" */,
+				E128E0B8288941DC00C5195F /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				E1BC3D8428B7E919007A7B39 /* XCRemoteSwiftPackageReference "LicensePlistViewController" */,
 				E144EBD428C63A31009B4900 /* XCRemoteSwiftPackageReference "MarkdownUI" */,
 				B9F5055629361F69009FE297 /* XCRemoteSwiftPackageReference "TCACoordinators" */,
 				43363E0529A79D6200E9FA23 /* XCRemoteSwiftPackageReference "unleash-proxy-client-swift" */,
@@ -1180,6 +1183,7 @@
 				B9A408A6292E231100EAB0B2 /* IdentificationCANScan.swift in Sources */,
 				E1AB87A02822972A00C7FC94 /* SetupPersonalPINIntroScreen.swift in Sources */,
 				D28D27FF28B7A91B008DA310 /* MissingPINLetter.swift in Sources */,
+				43BBC5332A177B57008212B7 /* LinkButton.swift in Sources */,
 				B974FD062926714500B338E5 /* IdentificationCANOrderNewPIN.swift in Sources */,
 				E1531DC429AE4994008D5185 /* AlertState+Confirmation.swift in Sources */,
 				E106614C28EC8C0C00CA2DB9 /* SharedScan.swift in Sources */,
@@ -1940,7 +1944,7 @@
 				minimumVersion = 0.3.0;
 			};
 		};
-		E128E0B8288941DC00C5195F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */ = {
+		E128E0B8288941DC00C5195F /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
@@ -1964,7 +1968,7 @@
 				minimumVersion = 2.0.0;
 			};
 		};
-		E1BC3D8428B7E919007A7B39 /* XCRemoteSwiftPackageReference "LicensePlistViewController.git" */ = {
+		E1BC3D8428B7E919007A7B39 /* XCRemoteSwiftPackageReference "LicensePlistViewController" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/yhirano/LicensePlistViewController.git";
 			requirement = {
@@ -1996,7 +2000,7 @@
 		};
 		E128E0B9288941DC00C5195F /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = E128E0B8288941DC00C5195F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
+			package = E128E0B8288941DC00C5195F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
 		};
 		E13925C1284110FD00161F5C /* Cuckoo */ = {
@@ -2011,7 +2015,7 @@
 		};
 		E1BC3D8528B7E919007A7B39 /* LicensePlistViewController */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = E1BC3D8428B7E919007A7B39 /* XCRemoteSwiftPackageReference "LicensePlistViewController.git" */;
+			package = E1BC3D8428B7E919007A7B39 /* XCRemoteSwiftPackageReference "LicensePlistViewController" */;
 			productName = LicensePlistViewController;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/BundesIdent/Theme/BundButtonStyle.swift
+++ b/BundesIdent/Theme/BundButtonStyle.swift
@@ -83,33 +83,6 @@ struct BundTextButtonStyle: ButtonStyle {
     }
 }
 
-struct BundLinkButtonStyle: ButtonStyle {
-
-    @Environment(\.isEnabled) var isEnabled: Bool
-
-    func makeBody(configuration: Configuration) -> some View {
-        let color = color(configuration: configuration)
-        if #available(iOS 16.0, *) {
-            configuration.label
-                .bodyLBold(color: color)
-                .minimumScaleFactor(0.5)
-                .underline()
-        } else {
-            configuration.label
-                .bodyLBold(color: color)
-                .minimumScaleFactor(0.5)
-                .overlay(Rectangle().fill(color).frame(height: 1.5).offset(y: -1.5), alignment: .bottom)
-        }
-    }
-
-    private func color(configuration: Configuration) -> Color {
-        guard isEnabled else {
-            return .neutral900
-        }
-        return configuration.isPressed ? .blue600 : .blue800
-    }
-}
-
 private func backgroundColor(configuration: ButtonStyleConfiguration,
                              isEnabled: Bool,
                              isPrimary: Bool,

--- a/BundesIdent/Theme/BundButtonStyle.swift
+++ b/BundesIdent/Theme/BundButtonStyle.swift
@@ -83,6 +83,33 @@ struct BundTextButtonStyle: ButtonStyle {
     }
 }
 
+struct BundLinkButtonStyle: ButtonStyle {
+
+    @Environment(\.isEnabled) var isEnabled: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        let color = color(configuration: configuration)
+        if #available(iOS 16.0, *) {
+            configuration.label
+                .bodyLBold(color: color)
+                .minimumScaleFactor(0.5)
+                .underline()
+        } else {
+            configuration.label
+                .bodyLBold(color: color)
+                .minimumScaleFactor(0.5)
+                .overlay(Rectangle().fill(color).frame(height: 1.5).offset(y: -1.5), alignment: .bottom)
+        }
+    }
+
+    private func color(configuration: Configuration) -> Color {
+        guard isEnabled else {
+            return .neutral900
+        }
+        return configuration.isPressed ? .blue600 : .blue800
+    }
+}
+
 private func backgroundColor(configuration: ButtonStyleConfiguration,
                              isEnabled: Bool,
                              isPrimary: Bool,

--- a/BundesIdent/Theme/Markdown.swift
+++ b/BundesIdent/Theme/Markdown.swift
@@ -18,9 +18,9 @@ extension Theme {
                 .relativeFrame(minWidth: .em(1.0), alignment: .trailing)
         }
         .listItem {
-            $0.markdownMargin(top: .em(0.7))
+            $0.label.markdownMargin(top: .em(0.7))
         }
         .paragraph {
-            $0.markdownMargin(top: .zero, bottom: .em(1.4))
+            $0.label.markdownMargin(top: .zero, bottom: .em(1.4))
         }
 }

--- a/BundesIdent/Theme/Markdown.swift
+++ b/BundesIdent/Theme/Markdown.swift
@@ -12,6 +12,7 @@ extension Theme {
         .link {
             FontWeight(.bold)
             ForegroundColor(.accentColor)
+            UnderlineStyle(.init(pattern: .solid, color: .accentColor))
         }
         .bulletedListMarker { _ in
             Text("• ")

--- a/BundesIdent/Views/Home/HomeView.swift
+++ b/BundesIdent/Views/Home/HomeView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import Combine
 import ComposableArchitecture
 import Analytics
-import MarkdownUI
 
 struct Home: ReducerProtocol {
 #if PREVIEW

--- a/BundesIdent/Views/SupplementaryViews/LinkButton.swift
+++ b/BundesIdent/Views/SupplementaryViews/LinkButton.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct LinkButton: View {
+    let text: String
+    let action: () -> Void
+
+    init(_ text: String, action: @escaping () -> Void) {
+        self.text = text
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            Text(text)
+                .underline()
+        }
+        .buttonStyle(BundLinkButtonStyle())
+    }
+}
+
+struct LinkButton_Previews: PreviewProvider {
+    static var previews: some View {
+        LinkButton("Link text") {}
+    }
+}
+
+private struct BundLinkButtonStyle: ButtonStyle {
+
+    @Environment(\.isEnabled) var isEnabled: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .bodyLBold(color: color(configuration: configuration))
+    }
+
+    private func color(configuration: Configuration) -> Color {
+        guard isEnabled else {
+            return .neutral900
+        }
+        return configuration.isPressed ? .blue600 : .blue800
+    }
+}


### PR DESCRIPTION
* Added underline for Markdown links
* Added new button type for standalone links

Considering the second point: Initially I tried more SwiftUI-y way with `BundLinkButtonStyle` (see https://github.com/digitalservicebund/useid-app-ios/pull/201/commits/1c628266e02fa101fa18a26c202117c6224337d0), but because `underline()` for `View` is only supported in iOS 16 we needed a workaround for iOS 15. This workaround had multiple downsides: only 1-line text would be supported (overlay is added to the whole view), the line wouldn’t grow with text size, so this fine adjustment to make it look exactly like links in other places wouldn’t be possible (or would require to much effort). So I changed the implementation to separate `LinkButton` that looks the same on all supported systems and doesn’t require fine tuning. 

|Before|After|
|-|-|
|<img width="300" alt="Screenshot 2023-05-19 at 12 43 57" src="https://github.com/digitalservicebund/useid-app-ios/assets/5408486/a7fae0dc-75de-42b6-bcee-6c07ec7c5e01">|<img width="300" alt="Screenshot 2023-05-19 at 12 43 23" src="https://github.com/digitalservicebund/useid-app-ios/assets/5408486/1332d31f-d00c-4277-a0e3-a089ecd53ac6">|
||(example of usage, not actually applied ⬇️)|
||<img width="300" alt="Screenshot 2023-05-19 at 12 43 12" src="https://github.com/digitalservicebund/useid-app-ios/assets/5408486/7e33c4ea-e78c-4ca3-8f45-a1d61367c43b">|